### PR TITLE
fix: input cell point to a forward output cell in same tx

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -252,8 +252,8 @@ mod tests {
         let data_a = random_bytes(1);
         db_file.write_all(&data_a).unwrap();
 
-        fs::create_dir("./free-space/test-snap").unwrap();
-        fs::create_dir("./free-space/test-snap/10").unwrap();
+        fs::create_dir_all("./free-space/test-snap/10").unwrap();
+        fs::create_dir("./free-space/test-snap/20").unwrap();
         let mut snap_file = fs::File::create("./free-space/test-snap/10/b.txt").unwrap();
         let data_b = random_bytes(2);
         snap_file.write_all(&data_b).unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -232,9 +232,12 @@ impl Service {
 
         let mut path = self.snapshot_path.clone();
         path.push(height.to_string());
+        let store = self.store.clone();
 
-        if let Err(e) = self.store.checkpoint(path) {
-            error!("build {} checkpoint failed: {:?}", height, e);
-        }
+        tokio::spawn(async move {
+            if let Err(e) = store.checkpoint(path) {
+                error!("build {} checkpoint failed: {:?}", height, e);
+            }
+        });
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -133,7 +133,7 @@ impl Service {
                 extensions.iter().for_each(|extension| {
                     extension
                         .append(&block)
-                        .expect("append block to extension should be OK")
+                        .unwrap_or_else(|e| panic!("append block error {:?}", e))
                 });
             };
 
@@ -144,7 +144,7 @@ impl Service {
                 extensions.iter().for_each(|extension| {
                     extension
                         .rollback(tip_number, &tip_hash)
-                        .expect("rollback in extension should be OK")
+                        .unwrap_or_else(|e| panic!("rollback error {:?}", e))
                 });
             };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,15 @@ pub fn to_fixed_array<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
     list
 }
 
+pub fn find<T: Eq>(key: &T, from: &[T]) -> Option<usize> {
+    for (index, item) in from.iter().enumerate() {
+        if item == key {
+            return Some(index);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,4 +70,11 @@ mod test {
         assert!(res.is_ok());
         assert_eq!(res.unwrap().network(), NetworkType::Testnet);
     }
+
+    #[test]
+    fn test_find() {
+        let test = (0..10).collect::<Vec<_>>();
+        test.iter()
+            .for_each(|i| assert_eq!(find(i, &test), Some(*i)));
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
If the extension cannot get a cell from ckb-indexer, the cell may point to an output cell in the same transaction. Extensions check whether the block transaction list contains the input cell transaction hash. Otherwise, get the cell from ckb-indexer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

