### PR TITLE
refactor(udt): add is_sudt flag in script value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8919aecb97e5ee9aceef27e24f39c46b11831130f4a6b7b091ec5de0de12"
+checksum = "76d99537dd7019c4dabfcf3898a43ee685412f76e6bee1ecc48785d730c1a275"
 dependencies = [
  "num-traits",
 ]
@@ -2348,9 +2348,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2403,9 +2403,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -2591,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg 1.0.1",
  "crossbeam-deque",
@@ -2603,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque",
@@ -3074,18 +3074,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3444,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"

--- a/src/extensions/udt_balance/mod.rs
+++ b/src/extensions/udt_balance/mod.rs
@@ -208,9 +208,9 @@ impl<S: Store, BS: Store> SUDTBalanceExtension<S, BS> {
 
     // This function should be run after fn is_sudt_cell(&cell).
     fn extract_udt_address_key(&self, cell: &packed::CellOutput) -> Vec<u8> {
-        let sudt_hash: H256 = self.get_type_hash(cell).unwrap().unpack();
+        let udt_hash: H256 = self.get_type_hash(cell).unwrap().unpack();
         let addr = self.parse_ckb_address(cell.lock()).to_string();
-        let mut key = sudt_hash.as_bytes().to_vec();
+        let mut key = udt_hash.as_bytes().to_vec();
         key.extend_from_slice(&addr.as_bytes());
         key
     }
@@ -224,13 +224,13 @@ impl<S: Store, BS: Store> SUDTBalanceExtension<S, BS> {
     ) {
         // This function runs when cell.is_sudt_cell() == true, so this unwrap() is safe.
         let key = self.extract_udt_address_key(cell);
-        let sudt_amount =
+        let udt_amount =
             u128::from_le_bytes(to_fixed_array::<UDT_AMOUNT_LEN>(&cell_data.to_vec()[0..16]));
 
         if is_sub {
-            *udt_balance_map.entry(key).or_insert_with(BigInt::zero) -= sudt_amount;
+            *udt_balance_map.entry(key).or_insert_with(BigInt::zero) -= udt_amount;
         } else {
-            *udt_balance_map.entry(key).or_insert_with(BigInt::zero) += sudt_amount;
+            *udt_balance_map.entry(key).or_insert_with(BigInt::zero) += udt_amount;
         }
     }
 
@@ -254,11 +254,11 @@ impl<S: Store, BS: Store> SUDTBalanceExtension<S, BS> {
         }
 
         for (script_hash, script) in sudt_script_map.iter() {
-            batch.put_kv(Key::ScriptHash(script_hash), Value::Script(script))?;
+            batch.put_kv(Key::ScriptHash(script_hash), Value::Script(true, script))?;
         }
 
         for (script_hash, script) in xudt_script_map.iter() {
-            batch.put_kv(Key::ScriptHash(script_hash), Value::Script(script))?;
+            batch.put_kv(Key::ScriptHash(script_hash), Value::Script(false, script))?;
         }
 
         batch.put_kv(

--- a/src/extensions/udt_balance/types.rs
+++ b/src/extensions/udt_balance/types.rs
@@ -101,7 +101,7 @@ impl<'a> Into<Vec<u8>> for Key<'a> {
 pub enum Value<'a> {
     SUDTBalance(u128),
     RollbackData(Vec<u8>),
-    Script(&'a packed::Script),
+    Script(bool, &'a packed::Script),
 }
 
 impl<'a> Into<Vec<u8>> for Value<'a> {
@@ -109,7 +109,11 @@ impl<'a> Into<Vec<u8>> for Value<'a> {
         match self {
             Value::SUDTBalance(balance) => Vec::from(balance.to_be_bytes()),
             Value::RollbackData(data) => data,
-            Value::Script(script) => script.as_slice().to_vec(),
+            Value::Script(is_sudt, script) => {
+                let mut encoded = vec![is_sudt as u8];
+                encoded.extend_from_slice(script.as_slice());
+                encoded
+            }
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Add is_sudt flag in Value::script. So that mercury can judge whether an udt_hash is of SUDT or not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

