### PR TITLE
refactor(rpc): get balance interface argument and response

### DIFF
--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -27,7 +27,11 @@ use jsonrpc_derive::rpc;
 #[rpc(server)]
 pub trait MercuryRpc {
     #[rpc(name = "get_balance")]
-    fn get_balance(&self, udt_hash: Option<H256>, addr: String) -> RpcResult<GetBalanceResponse>;
+    fn get_balance(
+        &self,
+        udt_hashes: Vec<Option<H256>>,
+        addr: String,
+    ) -> RpcResult<Vec<GetBalanceResponse>>;
 
     #[rpc(name = "is_in_rce_list")]
     fn is_in_rce_list(&self, rce_hash: H256, addr: H256) -> RpcResult<bool>;

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -77,10 +77,14 @@ where
     S: Store + Send + Sync + 'static,
     C: CkbRpc + Clone + Send + Sync + 'static,
 {
-    fn get_balance(&self, sudt_hash: Option<H256>, addr: String) -> RpcResult<GetBalanceResponse> {
-        log::debug!("get udt {:?} balance address {:?}", sudt_hash, addr);
+    fn get_balance(
+        &self,
+        sudt_hashes: Vec<Option<H256>>,
+        addr: String,
+    ) -> RpcResult<Vec<GetBalanceResponse>> {
+        log::debug!("get udt {:?} balance address {:?}", sudt_hashes, addr);
         let address = rpc_try!(parse_address(&addr));
-        let ret = rpc_try!(self.inner_get_balance(sudt_hash, &address));
+        let ret = rpc_try!(self.inner_get_balance(sudt_hashes, &address));
         log::debug!("sudt balance {:?}", ret);
         Ok(ret)
     }

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -30,8 +30,9 @@ where
         addr: &Address,
     ) -> Result<Vec<GetBalanceResponse>> {
         let mut ret = Vec::new();
+        let sp_cells = self.get_sp_detailed_cells(addr)?;
+
         for hash in udt_hashes.into_iter() {
-            let sp_cells = self.get_sp_detailed_cells(addr)?;
             let unconstrained = self.get_unconstrained_balance(hash.clone(), addr, &sp_cells)?;
             let locked = self.get_locked_balance(hash.clone(), addr, &sp_cells)?;
             let fleeting = self.get_fleeting_balance(hash.clone(), addr, &sp_cells)?;

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -26,15 +26,24 @@ where
 {
     pub(crate) fn inner_get_balance(
         &self,
-        udt_hash: Option<H256>,
+        udt_hashes: Vec<Option<H256>>,
         addr: &Address,
-    ) -> Result<GetBalanceResponse> {
-        let sp_cells = self.get_sp_detailed_cells(addr)?;
-        let unconstrained = self.get_unconstrained_balance(udt_hash.clone(), addr, &sp_cells)?;
-        let locked = self.get_locked_balance(udt_hash.clone(), addr, &sp_cells)?;
-        let fleeting = self.get_fleeting_balance(udt_hash, addr, &sp_cells)?;
-        let res = GetBalanceResponse::new(unconstrained, fleeting, locked);
-        Ok(res)
+    ) -> Result<Vec<GetBalanceResponse>> {
+        let mut ret = Vec::new();
+        for hash in udt_hashes.into_iter() {
+            let sp_cells = self.get_sp_detailed_cells(addr)?;
+            let unconstrained = self.get_unconstrained_balance(hash.clone(), addr, &sp_cells)?;
+            let locked = self.get_locked_balance(hash.clone(), addr, &sp_cells)?;
+            let fleeting = self.get_fleeting_balance(hash.clone(), addr, &sp_cells)?;
+            ret.push(GetBalanceResponse::new(
+                hash,
+                unconstrained,
+                fleeting,
+                locked,
+            ));
+        }
+
+        Ok(ret)
     }
 
     pub(crate) fn inner_scan_deposit(

--- a/core/rpc/src/tests/query_test.rs
+++ b/core/rpc/src/tests/query_test.rs
@@ -58,12 +58,12 @@ fn test_get_ckb_balance() {
     ]);
 
     let rpc = engine.rpc();
-    let ret_1 = rpc.get_balance(None, addr_1.to_string()).unwrap();
-    let ret_2 = rpc.get_balance(None, addr_2.to_string()).unwrap();
+    let ret_1 = rpc.get_balance(vec![None], addr_1.to_string()).unwrap();
+    let ret_2 = rpc.get_balance(vec![None], addr_2.to_string()).unwrap();
 
-    assert_eq!(ret_1.unconstrained, (500142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2.unconstrained, (1142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2.locked, (142 * BYTE_SHANNONS).to_string());
+    assert_eq!(ret_1[0].unconstrained, (500142 * BYTE_SHANNONS).to_string());
+    assert_eq!(ret_2[0].unconstrained, (1142 * BYTE_SHANNONS).to_string());
+    assert_eq!(ret_2[0].locked, (142 * BYTE_SHANNONS).to_string());
 }
 
 #[test]
@@ -76,19 +76,22 @@ fn test_get_ckb_balance_matured_cellbase() {
     ]);
 
     let rpc = engine.rpc();
-    let ret_1_at_genesis = rpc.get_balance(None, addr_1.to_string()).unwrap();
-    let ret_2_at_genesis = rpc.get_balance(None, addr_2.to_string()).unwrap();
+    let ret_1_at_genesis = rpc.get_balance(vec![None], addr_1.to_string()).unwrap();
+    let ret_2_at_genesis = rpc.get_balance(vec![None], addr_2.to_string()).unwrap();
 
     assert_eq!(
-        ret_1_at_genesis.unconstrained,
+        ret_1_at_genesis[0].unconstrained,
         (100_142 * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_2_at_genesis.unconstrained,
+        ret_2_at_genesis[0].unconstrained,
         (100_000 * BYTE_SHANNONS).to_string()
     );
-    assert_eq!(ret_1_at_genesis.locked, (142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2_at_genesis.locked, (0).to_string());
+    assert_eq!(
+        ret_1_at_genesis[0].locked,
+        (142 * BYTE_SHANNONS).to_string()
+    );
+    assert_eq!(ret_2_at_genesis[0].locked, (0).to_string());
 
     // Submit a cellbase tx mined by addr_1, expect to increase the locked balance by 1000 CKB
     let cellbase_tx = RpcTestEngine::build_cellbase_tx(addr_1, 1000);
@@ -96,11 +99,11 @@ fn test_get_ckb_balance_matured_cellbase() {
     engine.append(block_1);
 
     assert_eq!(
-        ret_1_at_genesis.unconstrained,
+        ret_1_at_genesis[0].unconstrained,
         (100_142 * BYTE_SHANNONS).to_string()
     );
-    let ret_at_block_1 = rpc.get_balance(None, addr_1.to_string()).unwrap();
-    assert_eq!(ret_at_block_1.locked, (1142 * BYTE_SHANNONS).to_string());
+    let ret_at_block_1 = rpc.get_balance(vec![None], addr_1.to_string()).unwrap();
+    assert_eq!(ret_at_block_1[0].locked, (1142 * BYTE_SHANNONS).to_string());
 
     // Submit another cellbase tx mined by addr_2, and set the block epoch bigger than `cellbase_maturity`,
     // expect to:
@@ -110,19 +113,25 @@ fn test_get_ckb_balance_matured_cellbase() {
     let block_2 = RpcTestEngine::new_block(vec![cellbase_tx], 2, 10);
     engine.append(block_2);
 
-    let ret_1_at_block_2 = rpc.get_balance(None, addr_1.to_string()).unwrap();
-    let ret_2_at_block_2 = rpc.get_balance(None, addr_2.to_string()).unwrap();
+    let ret_1_at_block_2 = rpc.get_balance(vec![None], addr_1.to_string()).unwrap();
+    let ret_2_at_block_2 = rpc.get_balance(vec![None], addr_2.to_string()).unwrap();
 
     assert_eq!(
-        ret_1_at_block_2.unconstrained,
+        ret_1_at_block_2[0].unconstrained,
         ((100_142 + 1000) * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_2_at_block_2.unconstrained,
+        ret_2_at_block_2[0].unconstrained,
         (100_000 * BYTE_SHANNONS).to_string()
     );
-    assert_eq!(ret_1_at_block_2.locked, (142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2_at_block_2.locked, (1000 * BYTE_SHANNONS).to_string());
+    assert_eq!(
+        ret_1_at_block_2[0].locked,
+        (142 * BYTE_SHANNONS).to_string()
+    );
+    assert_eq!(
+        ret_2_at_block_2[0].locked,
+        (1000 * BYTE_SHANNONS).to_string()
+    );
 }
 
 #[test]
@@ -139,14 +148,14 @@ fn test_get_udt_balance() {
 
     let rpc = engine.rpc();
     let ret_1 = rpc
-        .get_balance(Some(SUDT_HASH.read().clone()), addr_1.to_string())
+        .get_balance(vec![Some(SUDT_HASH.read().clone())], addr_1.to_string())
         .unwrap();
     let ret_2 = rpc
-        .get_balance(Some(SUDT_HASH.read().clone()), addr_2.to_string())
+        .get_balance(vec![Some(SUDT_HASH.read().clone())], addr_2.to_string())
         .unwrap();
 
-    assert_eq!(ret_1.unconstrained, 300.to_string());
-    assert_eq!(ret_2.unconstrained, 300.to_string());
+    assert_eq!(ret_1[0].unconstrained, 300.to_string());
+    assert_eq!(ret_2[0].unconstrained, 300.to_string());
 }
 
 #[test]

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -104,14 +104,16 @@ impl ScriptType {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GetBalanceResponse {
+    pub udt_hash: Option<H256>,
     pub unconstrained: String,
     pub fleeting: String,
     pub locked: String,
 }
 
 impl GetBalanceResponse {
-    pub fn new(unconstrained: u128, fleeting: u128, locked: u128) -> Self {
+    pub fn new(udt_hash: Option<H256>, unconstrained: u128, fleeting: u128, locked: u128) -> Self {
         GetBalanceResponse {
+            udt_hash,
             unconstrained: unconstrained.to_string(),
             fleeting: fleeting.to_string(),
             locked: locked.to_string(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Change the `udt_hash` argument to a `Vec`.
Change the rpc response to a `Vec`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

