### PR TITLE
refactor(rpc): change the  get balance interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1868,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dea6388d3d5498ec651701f14edbaf463c924b5d8829fb2848ccf0bcc7b3c69"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -251,13 +251,13 @@ impl Address {
     }
 
     pub fn is_secp256k1(&self) -> bool {
-        match self.payload {
-            AddressPayload::Short { index, .. } => index == CodeHashIndex::Sighash,
+        match &self.payload {
+            AddressPayload::Short { index, .. } => index == &CodeHashIndex::Sighash,
             AddressPayload::Full {
                 hash_type,
                 code_hash,
                 ..
-            } => hash_type == ScriptHashType::Type && code_hash == SIGHASH_TYPE_HASH.pack(),
+            } => hash_type == &ScriptHashType::Type && code_hash == &SIGHASH_TYPE_HASH.pack(),
         }
     }
 }

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -223,6 +223,7 @@ impl Address {
     pub fn network(&self) -> NetworkType {
         self.network
     }
+
     pub fn payload(&self) -> &AddressPayload {
         &self.payload
     }
@@ -247,6 +248,17 @@ impl Address {
         let value = Bech32::new(hrp.to_string(), data.to_base32())
             .unwrap_or_else(|_| panic!("Encode address failed: payload={:?}", self.payload));
         format!("{}", value)
+    }
+
+    pub fn is_secp256k1(&self) -> bool {
+        match self.payload {
+            AddressPayload::Short { index, .. } => index == CodeHashIndex::Sighash,
+            AddressPayload::Full {
+                hash_type,
+                code_hash,
+                ..
+            } => hash_type == ScriptHashType::Type && code_hash == SIGHASH_TYPE_HASH.pack(),
+        }
     }
 }
 

--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -56,4 +56,7 @@ pub(crate) enum RpcError {
 
     #[display(fmt = "Can not find change cell")]
     CannotFindChangeCell,
+
+    #[display(fmt = "Key address must be an Secp256k1 address")]
+    KeyAddressIsNotSecp256k1,
 }

--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -59,4 +59,7 @@ pub(crate) enum RpcError {
 
     #[display(fmt = "Key address must be an Secp256k1 address")]
     KeyAddressIsNotSecp256k1,
+
+    #[display(fmt = "Invalid normal address")]
+    InvalidNormalAddress,
 }

--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -60,6 +60,6 @@ pub(crate) enum RpcError {
     #[display(fmt = "Key address must be an Secp256k1 address")]
     KeyAddressIsNotSecp256k1,
 
-    #[display(fmt = "Invalid normal address")]
-    InvalidNormalAddress,
+    #[display(fmt = "Unsupported normal address")]
+    UnsupportedNormalAddress,
 }

--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -62,4 +62,7 @@ pub(crate) enum RpcError {
 
     #[display(fmt = "Unsupported normal address")]
     UnsupportedNormalAddress,
+
+    #[display(fmt = "Get Balance by block number not support yet")]
+    GetBalanceByBlockNumberNotSupportYet,
 }

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -9,8 +9,8 @@ mod error;
 mod tests;
 
 use types::{
-    CreateWalletPayload, GetBalanceResponse, ScanBlockPayload, ScanBlockResponse,
-    TransactionCompletionResponse, TransferPayload,
+    CreateWalletPayload, GetBalancePayload, GetBalanceResponse, ScanBlockPayload,
+    ScanBlockResponse, TransactionCompletionResponse, TransferPayload,
 };
 
 pub use ckb_client::CkbRpcClient;
@@ -27,11 +27,7 @@ use jsonrpc_derive::rpc;
 #[rpc(server)]
 pub trait MercuryRpc {
     #[rpc(name = "get_balance")]
-    fn get_balance(
-        &self,
-        udt_hashes: Vec<Option<H256>>,
-        addr: String,
-    ) -> RpcResult<Vec<GetBalanceResponse>>;
+    fn get_balance(&self, payload: GetBalancePayload) -> RpcResult<Vec<GetBalanceResponse>>;
 
     #[rpc(name = "is_in_rce_list")]
     fn is_in_rce_list(&self, rce_hash: H256, addr: H256) -> RpcResult<bool>;

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -14,7 +14,7 @@ use types::{
 };
 
 pub use ckb_client::CkbRpcClient;
-pub use rpc_impl::{MercuryRpcImpl, TX_POOL_CACHE, USE_HEX_FORMAT};
+pub use rpc_impl::{MercuryRpcImpl, CURRENT_BLOCK_NUMBER, TX_POOL_CACHE, USE_HEX_FORMAT};
 
 use common::anyhow::Result;
 
@@ -27,7 +27,7 @@ use jsonrpc_derive::rpc;
 #[rpc(server)]
 pub trait MercuryRpc {
     #[rpc(name = "get_balance")]
-    fn get_balance(&self, payload: GetBalancePayload) -> RpcResult<Vec<GetBalanceResponse>>;
+    fn get_balance(&self, payload: GetBalancePayload) -> RpcResult<GetBalanceResponse>;
 
     #[rpc(name = "is_in_rce_list")]
     fn is_in_rce_list(&self, rce_hash: H256, addr: H256) -> RpcResult<bool>;

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -181,7 +181,7 @@ pub fn parse_normal_address(addr: &str) -> Result<Address> {
     Address::from_str(addr).map_err(|e| anyhow!("{:?}", e))
 }
 
-pub fn lock_args_to_sp_key(lock_args: Bytes) -> H160 {
+pub fn pubkey_to_secp_address(lock_args: Bytes) -> H160 {
     let pubkey_hash = H160::from_slice(&lock_args[0..20]).unwrap();
     let script = packed::Script::from(&AddressPayload::new_short(
         CodeHashIndex::Sighash,

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -2,8 +2,8 @@ mod query;
 mod transfer;
 
 use crate::types::{
-    CreateWalletPayload, GetBalanceResponse, ScanBlockPayload, ScanBlockResponse,
-    TransactionCompletionResponse, TransferPayload,
+    CreateWalletPayload, GetBalancePayload, GetBalanceResponse, ScanBlockPayload,
+    ScanBlockResponse, TransactionCompletionResponse, TransferPayload,
 };
 use crate::{CkbRpc, MercuryRpc};
 
@@ -77,14 +77,10 @@ where
     S: Store + Send + Sync + 'static,
     C: CkbRpc + Clone + Send + Sync + 'static,
 {
-    fn get_balance(
-        &self,
-        sudt_hashes: Vec<Option<H256>>,
-        addr: String,
-    ) -> RpcResult<Vec<GetBalanceResponse>> {
-        log::debug!("get udt {:?} balance address {:?}", sudt_hashes, addr);
-        let address = rpc_try!(parse_address(&addr));
-        let ret = rpc_try!(self.inner_get_balance(sudt_hashes, &address));
+    fn get_balance(&self, payload: GetBalancePayload) -> RpcResult<Vec<GetBalanceResponse>> {
+        log::debug!("get balance payload {:?}", payload);
+        let address = rpc_try!(parse_address(&payload.address));
+        let ret = rpc_try!(self.inner_get_balance(payload.udt_hashes, &address));
         log::debug!("sudt balance {:?}", ret);
         Ok(ret)
     }

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -1,5 +1,11 @@
-use crate::rpc_impl::{address_to_script, MercuryRpcImpl, CURRENT_BLOCK_NUMBER, USE_HEX_FORMAT};
-use crate::types::{Balance, GetBalanceResponse, InnerCharge, ScanBlockResponse, ScriptType};
+use crate::rpc_impl::{
+    address_to_script, lock_args_to_sp_key, parse_key_address, parse_normal_address,
+    MercuryRpcImpl, CURRENT_BLOCK_NUMBER, USE_HEX_FORMAT,
+};
+use crate::types::{
+    Balance, GetBalanceResponse, InnerBalance, InnerCharge, QueryAddress, ScanBlockResponse,
+    ScriptType,
+};
 use crate::{block_on, error::RpcError, CkbRpc};
 
 use common::utils::{decode_udt_amount, parse_address, to_fixed_array};
@@ -27,27 +33,175 @@ where
     pub(crate) fn inner_get_balance(
         &self,
         udt_hashes: HashSet<Option<H256>>,
-        addr: &Address,
+        address: QueryAddress,
         block_number: Option<u64>,
     ) -> Result<GetBalanceResponse> {
-        let mut balances = Vec::new();
-        let sp_cells = self.get_sp_detailed_cells(addr)?;
+        let bal = match address {
+            QueryAddress::KeyAddress(addr) => {
+                let addr = parse_key_address(&addr)?;
+                let mut balances = Vec::new();
+                let sp_cells = self.get_sp_detailed_cells(&addr)?;
 
-        let udt_hashes_iter = if udt_hashes.is_empty() {
-            self.get_all_udt_hashes()?.into_iter()
-        } else {
-            udt_hashes.into_iter()
+                let udt_hashes_iter = if udt_hashes.is_empty() {
+                    self.get_all_udt_hashes()?.into_iter()
+                } else {
+                    udt_hashes.into_iter()
+                };
+
+                for hash in udt_hashes_iter {
+                    let unconstrained =
+                        self.get_unconstrained_balance(hash.clone(), &addr, &sp_cells)?;
+                    let locked = self.get_locked_balance(hash.clone(), &addr, &sp_cells)?;
+                    let fleeting = self.get_fleeting_balance(hash.clone(), &addr, &sp_cells)?;
+                    balances.push(Balance::new(hash, unconstrained, fleeting, locked));
+                }
+                balances
+            }
+
+            QueryAddress::NormalAddress(addr) => {
+                let addr = parse_normal_address(&addr)?;
+                let script = address_to_script(addr.payload());
+
+                if self.is_secp256k1(&script) {
+                    self.inner_get_secp_balance(udt_hashes, &addr)?
+                } else if self.is_acp(&script) {
+                    self.inner_get_acp_balance(udt_hashes, &addr)?
+                } else if self.is_cheque(&script) {
+                    self.inner_get_cheque_balance(udt_hashes, &addr)?
+                } else {
+                    Vec::new()
+                }
+            }
         };
 
-        for hash in udt_hashes_iter {
-            let unconstrained = self.get_unconstrained_balance(hash.clone(), addr, &sp_cells)?;
-            let locked = self.get_locked_balance(hash.clone(), addr, &sp_cells)?;
-            let fleeting = self.get_fleeting_balance(hash.clone(), addr, &sp_cells)?;
-            balances.push(Balance::new(hash, unconstrained, fleeting, locked));
+        let block_num = block_number.unwrap_or_else(|| **CURRENT_BLOCK_NUMBER.load());
+        Ok(GetBalanceResponse::new(block_num, bal))
+    }
+
+    pub(crate) fn inner_get_secp_balance(
+        &self,
+        udt_hashes: HashSet<Option<H256>>,
+        addr: &Address,
+    ) -> Result<Vec<Balance>> {
+        let mut balances = Vec::new();
+
+        for hash in udt_hashes.into_iter() {
+            let unconstrained = if let Some(hash) = hash.clone() {
+                self.udt_balance(addr, &hash)?.unwrap_or(0)
+            } else {
+                self.ckb_balance(addr)? as u128
+            };
+
+            balances.push(Balance::new(hash, unconstrained, 0, 0));
         }
 
-        let block_num = block_number.unwrap_or_else(|| **CURRENT_BLOCK_NUMBER.load());
-        Ok(GetBalanceResponse::new(block_num, balances))
+        Ok(balances)
+    }
+
+    pub(crate) fn inner_get_acp_balance(
+        &self,
+        udt_hashes: HashSet<Option<H256>>,
+        addr: &Address,
+    ) -> Result<Vec<Balance>> {
+        let mut balances = udt_hashes
+            .into_iter()
+            .map(|hash| (hash.clone(), InnerBalance::new(hash)))
+            .collect::<HashMap<_, _>>();
+        let script = address_to_script(addr.payload());
+        let key = lock_args_to_sp_key(addr.payload().args());
+        let cells = self
+            .store_get(
+                *SP_CELL_EXT_PREFIX,
+                special_cells::Key::CkbAddress(&key).into_vec(),
+            )?
+            .map_or_else(DetailedCells::default, |bytes| deserialize(&bytes).unwrap());
+        let mut ckb_locked = 0;
+
+        for cell in cells
+            .0
+            .iter()
+            .filter(|cell| cell.cell_output.lock() == script)
+        {
+            if cell.cell_output.type_().is_none() {
+                if let Some(bal) = balances.get_mut(&None) {
+                    let unconstrained: u64 = cell.cell_output.capacity().unpack();
+                    bal.unconstrained += unconstrained;
+                }
+            } else {
+                let udt_hash: H256 = cell
+                    .cell_output
+                    .type_()
+                    .to_opt()
+                    .unwrap()
+                    .calc_script_hash()
+                    .unpack();
+                if let Some(bal) = balances.get_mut(&Some(udt_hash)) {
+                    let locked: u64 = cell.cell_output.capacity().unpack();
+                    let unconstrained = decode_udt_amount(&cell.cell_data.raw_data());
+                    bal.unconstrained += unconstrained;
+                    ckb_locked += locked;
+                }
+            }
+        }
+
+        if let Some(bal) = balances.get_mut(&None) {
+            bal.locked += ckb_locked;
+        }
+
+        Ok(balances.into_iter().map(|(_k, v)| v.into()).collect())
+    }
+
+    pub(crate) fn inner_get_cheque_balance(
+        &self,
+        udt_hashes: HashSet<Option<H256>>,
+        addr: &Address,
+    ) -> Result<Vec<Balance>> {
+        let mut balances = udt_hashes
+            .into_iter()
+            .map(|hash| (hash.clone(), InnerBalance::new(hash)))
+            .collect::<HashMap<_, _>>();
+        let script = address_to_script(addr.payload());
+        let key = lock_args_to_sp_key(addr.payload().args());
+        let cells = self
+            .store_get(
+                *SP_CELL_EXT_PREFIX,
+                special_cells::Key::CkbAddress(&key).into_vec(),
+            )?
+            .map_or_else(DetailedCells::default, |bytes| deserialize(&bytes).unwrap());
+        let mut ckb_locked = 0;
+
+        for cell in cells
+            .0
+            .iter()
+            .filter(|cell| cell.cell_output.lock() == script)
+        {
+            if cell.cell_output.type_().is_none() {
+                if let Some(bal) = balances.get_mut(&None) {
+                    let fleeting: u64 = cell.cell_output.capacity().unpack();
+                    bal.fleeting += fleeting;
+                }
+            } else {
+                let udt_hash: H256 = cell
+                    .cell_output
+                    .type_()
+                    .to_opt()
+                    .unwrap()
+                    .calc_script_hash()
+                    .unpack();
+                if let Some(bal) = balances.get_mut(&Some(udt_hash)) {
+                    let locked: u64 = cell.cell_output.capacity().unpack();
+                    let fleeting = decode_udt_amount(&cell.cell_data.raw_data());
+                    bal.fleeting += fleeting;
+                    ckb_locked += locked;
+                }
+            }
+        }
+
+        if let Some(bal) = balances.get_mut(&None) {
+            bal.locked += ckb_locked;
+        }
+
+        Ok(balances.into_iter().map(|(_k, v)| v.into()).collect())
     }
 
     pub(crate) fn inner_scan_deposit(
@@ -213,7 +367,7 @@ where
         sp_cells: &DetailedCells,
     ) -> Result<u128> {
         if let Some(hash) = udt_hash {
-            let unconstrained_udt_balance = self.udt_balance(addr, hash.clone())?.unwrap_or(0);
+            let unconstrained_udt_balance = self.udt_balance(addr, &hash)?.unwrap_or(0);
             let acp_unconstrained_udt_balance =
                 self.acp_unconstrained_udt_balance(hash.clone(), sp_cells)? as u128;
             let cheque_unconstrained_udt_balance =
@@ -385,6 +539,7 @@ where
             .sum();
         Ok(unconstrained_udt_balance)
     }
+
     pub(crate) fn cheque_fleeting_udt_balance(
         &self,
         addr: &Address,
@@ -471,7 +626,7 @@ where
         Ok(balance.normal_cell_capacity + balance.udt_cell_capacity)
     }
 
-    pub(crate) fn udt_balance(&self, addr: &Address, udt_hash: H256) -> Result<Option<u128>> {
+    pub(crate) fn udt_balance(&self, addr: &Address, udt_hash: &H256) -> Result<Option<u128>> {
         let mut encoded = udt_hash.as_bytes().to_vec();
         encoded.extend_from_slice(&lock_hash(addr));
         let key = udt_balance::Key::Address(&encoded);
@@ -490,6 +645,24 @@ where
         } else {
             Ok(Default::default())
         }
+    }
+
+    fn is_secp256k1(&self, script: &packed::Script) -> bool {
+        let config = self.config.get(ckb_balance::SECP256K1_BLAKE160).unwrap();
+        config.script.hash_type() == script.hash_type()
+            && config.script.code_hash() == script.code_hash()
+    }
+
+    fn is_acp(&self, script: &packed::Script) -> bool {
+        let config = self.config.get(special_cells::ACP).unwrap();
+        config.script.hash_type() == script.hash_type()
+            && config.script.code_hash() == script.code_hash()
+    }
+
+    fn is_cheque(&self, script: &packed::Script) -> bool {
+        let config = self.config.get(special_cells::CHEQUE).unwrap();
+        config.script.hash_type() == script.hash_type()
+            && config.script.code_hash() == script.code_hash()
     }
 
     pub(crate) fn get_cells_by_lock_script(

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -36,6 +36,13 @@ where
         address: QueryAddress,
         block_number: Option<u64>,
     ) -> Result<GetBalanceResponse> {
+        // todo: After support search according to height, the process should be:  if search for latest height (default mode), we should get `CURRENT_BLOCK_NUMBER` first, and then query according to height
+        let block_num = if block_number.is_some() {
+            return Err(MercuryError::rpc(RpcError::GetBalanceByBlockNumberNotSupportYet).into());
+        } else {
+            **CURRENT_BLOCK_NUMBER.load()
+        };
+
         let udt_hashes = if udt_hashes.is_empty() {
             self.get_all_udt_hashes()?
         } else {
@@ -77,8 +84,7 @@ where
                 }
             }
         };
-        // todo: After support search according to height, the process should be:  if search for latest height (default mode), we should get `CURRENT_BLOCK_NUMBER` first, and then query according to height
-        let block_num = block_number.unwrap_or_else(|| **CURRENT_BLOCK_NUMBER.load());
+
         Ok(GetBalanceResponse::new(block_num, bal))
     }
 

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -604,11 +604,11 @@ where
             && config.script.code_hash() == script.code_hash()
     }
 
-    fn is_cheque(&self, script: &packed::Script) -> bool {
-        let config = self.config.get(special_cells::CHEQUE).unwrap();
-        config.script.hash_type() == script.hash_type()
-            && config.script.code_hash() == script.code_hash()
-    }
+    // fn is_cheque(&self, script: &packed::Script) -> bool {
+    //     let config = self.config.get(special_cells::CHEQUE).unwrap();
+    //     config.script.hash_type() == script.hash_type()
+    //         && config.script.code_hash() == script.code_hash()
+    // }
 
     pub(crate) fn get_cells_by_lock_script(
         &self,

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -77,7 +77,7 @@ where
                 }
             }
         };
-
+// todo: After support search according to height, the process should be:  if search for latest height (default mode), we should get `CURRENT_BLOCK_NUMBER` first, and then query according to height
         let block_num = block_number.unwrap_or_else(|| **CURRENT_BLOCK_NUMBER.load());
         Ok(GetBalanceResponse::new(block_num, bal))
     }

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -36,19 +36,19 @@ where
         address: QueryAddress,
         block_number: Option<u64>,
     ) -> Result<GetBalanceResponse> {
+        let udt_hashes = if udt_hashes.is_empty() {
+            self.get_all_udt_hashes()?
+        } else {
+            udt_hashes
+        };
+
         let bal = match address {
             QueryAddress::KeyAddress(addr) => {
                 let addr = parse_key_address(&addr)?;
                 let mut balances = Vec::new();
                 let sp_cells = self.get_sp_detailed_cells(&addr)?;
 
-                let udt_hashes_iter = if udt_hashes.is_empty() {
-                    self.get_all_udt_hashes()?.into_iter()
-                } else {
-                    udt_hashes.into_iter()
-                };
-
-                for hash in udt_hashes_iter {
+                for hash in udt_hashes.into_iter() {
                     let unconstrained =
                         self.get_unconstrained_balance(hash.clone(), &addr, &sp_cells)?;
                     let locked = self.get_locked_balance(hash.clone(), &addr, &sp_cells)?;

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -73,7 +73,7 @@ where
                 } else if self.is_acp(&script) {
                     self.inner_get_acp_balance(udt_hashes, &addr)?
                 } else {
-                    return Err(MercuryError::rpc(RpcError::InvalidNormalAddress).into());
+                    return Err(MercuryError::rpc(RpcError::UnsupportedNormalAddress).into());
                 }
             }
         };

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -77,7 +77,7 @@ where
                 }
             }
         };
-// todo: After support search according to height, the process should be:  if search for latest height (default mode), we should get `CURRENT_BLOCK_NUMBER` first, and then query according to height
+        // todo: After support search according to height, the process should be:  if search for latest height (default mode), we should get `CURRENT_BLOCK_NUMBER` first, and then query according to height
         let block_num = block_number.unwrap_or_else(|| **CURRENT_BLOCK_NUMBER.load());
         Ok(GetBalanceResponse::new(block_num, bal))
     }

--- a/core/rpc/src/rpc_impl/transfer.rs
+++ b/core/rpc/src/rpc_impl/transfer.rs
@@ -5,7 +5,8 @@ use crate::rpc_impl::{
 };
 use crate::types::{
     details_split_off, CellWithData, DetailedAmount, InnerAccount, InnerTransferItem, InputConsume,
-    ScriptType, SignatureEntry, TransactionCompletionResponse, WalletInfo, CHEQUE, SECP256K1,
+    ScriptType, SignatureEntry, SignatureFunc, TransactionCompletionResponse, WalletInfo, CHEQUE,
+    SECP256K1,
 };
 use crate::{block_on, error::RpcError, CkbRpc};
 
@@ -468,7 +469,11 @@ where
             *udt_sum += amount;
 
             let addr = Address::new(self.net_ty, addr.clone()).to_string();
-            sigs_entry.push(SignatureEntry::new(inputs.len() - 1, addr));
+            sigs_entry.push(SignatureEntry::new(
+                inputs.len() - 1,
+                addr,
+                SignatureFunc::Secp256k1,
+            ));
         }
 
         Ok(())
@@ -769,6 +774,7 @@ where
                 sigs_entry.push(SignatureEntry::new(
                     inputs.len() - 1,
                     from.display_with_network(self.net_ty),
+                    SignatureFunc::Secp256k1,
                 ));
             }
         }
@@ -806,7 +812,10 @@ where
             if let Some(entry) = sigs_entry.get_mut(&addr) {
                 entry.add_group();
             } else {
-                sigs_entry.insert(addr.clone(), SignatureEntry::new(inputs.len() - 1, addr));
+                sigs_entry.insert(
+                    addr.clone(),
+                    SignatureEntry::new(inputs.len() - 1, addr, SignatureFunc::Secp256k1),
+                );
             }
         }
     }
@@ -844,7 +853,10 @@ where
             if let Some(entry) = sigs_entry.get_mut(&addr) {
                 entry.add_group();
             } else {
-                sigs_entry.insert(addr.clone(), SignatureEntry::new(inputs.len() - 1, addr));
+                sigs_entry.insert(
+                    addr.clone(),
+                    SignatureEntry::new(inputs.len() - 1, addr, SignatureFunc::Secp256k1),
+                );
             }
         }
     }

--- a/core/rpc/src/rpc_impl/transfer.rs
+++ b/core/rpc/src/rpc_impl/transfer.rs
@@ -5,7 +5,7 @@ use crate::rpc_impl::{
 };
 use crate::types::{
     details_split_off, CellWithData, DetailedAmount, InnerAccount, InnerTransferItem, InputConsume,
-    ScriptType, SignatureEntry, SignatureFunc, TransactionCompletionResponse, WalletInfo, CHEQUE,
+    ScriptType, SignatureEntry, SignatureType, TransactionCompletionResponse, WalletInfo, CHEQUE,
     SECP256K1,
 };
 use crate::{block_on, error::RpcError, CkbRpc};
@@ -472,7 +472,7 @@ where
             sigs_entry.push(SignatureEntry::new(
                 inputs.len() - 1,
                 addr,
-                SignatureFunc::Secp256k1,
+                SignatureType::Secp256k1,
             ));
         }
 
@@ -774,7 +774,7 @@ where
                 sigs_entry.push(SignatureEntry::new(
                     inputs.len() - 1,
                     from.display_with_network(self.net_ty),
-                    SignatureFunc::Secp256k1,
+                    SignatureType::Secp256k1,
                 ));
             }
         }
@@ -814,7 +814,7 @@ where
             } else {
                 sigs_entry.insert(
                     addr.clone(),
-                    SignatureEntry::new(inputs.len() - 1, addr, SignatureFunc::Secp256k1),
+                    SignatureEntry::new(inputs.len() - 1, addr, SignatureType::Secp256k1),
                 );
             }
         }
@@ -855,7 +855,7 @@ where
             } else {
                 sigs_entry.insert(
                     addr.clone(),
-                    SignatureEntry::new(inputs.len() - 1, addr, SignatureFunc::Secp256k1),
+                    SignatureEntry::new(inputs.len() - 1, addr, SignatureType::Secp256k1),
                 );
             }
         }

--- a/core/rpc/src/tests/mod.rs
+++ b/core/rpc/src/tests/mod.rs
@@ -8,7 +8,7 @@ use crate::rpc_impl::{
     address_to_script, BYTE_SHANNONS, CHEQUE_CELL_CAPACITY, STANDARD_SUDT_CAPACITY,
 };
 use crate::types::{
-    Action, CreateWalletPayload, FromAccount, GetBalancePayload, Source, ToAccount,
+    Action, CreateWalletPayload, FromAccount, GetBalancePayload, QueryAddress, Source, ToAccount,
     TransactionCompletionResponse, TransferItem, TransferPayload, WalletInfo,
 };
 use crate::{CkbRpcClient, MercuryRpc, MercuryRpcImpl};

--- a/core/rpc/src/tests/mod.rs
+++ b/core/rpc/src/tests/mod.rs
@@ -8,8 +8,8 @@ use crate::rpc_impl::{
     address_to_script, BYTE_SHANNONS, CHEQUE_CELL_CAPACITY, STANDARD_SUDT_CAPACITY,
 };
 use crate::types::{
-    Action, CreateWalletPayload, FromAccount, Source, ToAccount, TransactionCompletionResponse,
-    TransferItem, TransferPayload, WalletInfo,
+    Action, CreateWalletPayload, FromAccount, GetBalancePayload, Source, ToAccount,
+    TransactionCompletionResponse, TransferItem, TransferPayload, WalletInfo,
 };
 use crate::{CkbRpcClient, MercuryRpc, MercuryRpcImpl};
 
@@ -51,28 +51,18 @@ lazy_static::lazy_static! {
     pub static ref SUDT_HASH: RwLock<H256> = RwLock::new(Default::default());
 }
 
-// macro_rules! transaction {
-//     ([$($input: expr), *], [$($output: expr), *]) => {
-//         let (mut inputs, mut outputs, mut data) = (vec![], vec![], vec![]);
-//         $(inputs.push(
-//             packed::CellInputBuilder::default()
-//                 .previous_output(input)
-//                 .build()
-//             );
-//         )*
+#[macro_export]
+macro_rules! hashset {
+    () => {{
+        HashSet::new()
+    }};
 
-//         $(
-//             outputs.push($output.cell_output);
-//             data.push($output.cell_data);
-//         )*
-
-//         TransactionBuilder::default()
-//             .witness(Script::default().into_witness())
-//             .inputs(inputs).outputs(outputs)
-//             .outputs_data(data)
-//             .build()
-//     };
-// }
+    ($($input: expr), *) => {{
+        let mut set = std::collections::HashSet::new();
+        $(set.insert($input);)*
+        set
+    }};
+}
 
 pub struct RpcTestEngine {
     pub store: MemoryDB,

--- a/core/rpc/src/tests/query_test.rs
+++ b/core/rpc/src/tests/query_test.rs
@@ -62,14 +62,14 @@ fn test_get_ckb_balance() {
     let ret_1 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_2.to_string(),
+            address: QueryAddress::KeyAddress(addr_2.to_string()),
             block_number: None,
         })
         .unwrap();
@@ -98,14 +98,14 @@ fn test_get_ckb_balance_matured_cellbase() {
     let ret_1_at_genesis = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
     let ret_2_at_genesis = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_2.to_string(),
+            address: QueryAddress::KeyAddress(addr_2.to_string()),
             block_number: None,
         })
         .unwrap();
@@ -136,7 +136,7 @@ fn test_get_ckb_balance_matured_cellbase() {
     let ret_at_block_1 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
@@ -156,14 +156,14 @@ fn test_get_ckb_balance_matured_cellbase() {
     let ret_1_at_block_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
     let ret_2_at_block_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
-            address: addr_2.to_string(),
+            address: QueryAddress::KeyAddress(addr_2.to_string()),
             block_number: None,
         })
         .unwrap();
@@ -202,14 +202,14 @@ fn test_get_udt_balance() {
     let ret_1 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![Some(SUDT_HASH.read().clone())],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![Some(SUDT_HASH.read().clone())],
-            address: addr_2.to_string(),
+            address: QueryAddress::KeyAddress(addr_2.to_string()),
             block_number: None,
         })
         .unwrap();
@@ -234,14 +234,14 @@ fn test_get_all_udt_balance() {
     let ret_1 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![],
-            address: addr_1.to_string(),
+            address: QueryAddress::KeyAddress(addr_1.to_string()),
             block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![],
-            address: addr_2.to_string(),
+            address: QueryAddress::KeyAddress(addr_2.to_string()),
             block_number: None,
         })
         .unwrap();

--- a/core/rpc/src/tests/query_test.rs
+++ b/core/rpc/src/tests/query_test.rs
@@ -63,18 +63,26 @@ fn test_get_ckb_balance() {
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_2.to_string(),
+            block_number: None,
         })
         .unwrap();
 
-    assert_eq!(ret_1[0].unconstrained, (500142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2[0].unconstrained, (1142 * BYTE_SHANNONS).to_string());
-    assert_eq!(ret_2[0].locked, (142 * BYTE_SHANNONS).to_string());
+    assert_eq!(
+        ret_1.balances[0].unconstrained,
+        (500142 * BYTE_SHANNONS).to_string()
+    );
+    assert_eq!(
+        ret_2.balances[0].unconstrained,
+        (1142 * BYTE_SHANNONS).to_string()
+    );
+    assert_eq!(ret_2.balances[0].locked, (142 * BYTE_SHANNONS).to_string());
 }
 
 #[test]
@@ -91,28 +99,30 @@ fn test_get_ckb_balance_matured_cellbase() {
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
     let ret_2_at_genesis = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_2.to_string(),
+            block_number: None,
         })
         .unwrap();
 
     assert_eq!(
-        ret_1_at_genesis[0].unconstrained,
+        ret_1_at_genesis.balances[0].unconstrained,
         (100_142 * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_2_at_genesis[0].unconstrained,
+        ret_2_at_genesis.balances[0].unconstrained,
         (100_000 * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_1_at_genesis[0].locked,
+        ret_1_at_genesis.balances[0].locked,
         (142 * BYTE_SHANNONS).to_string()
     );
-    assert_eq!(ret_2_at_genesis[0].locked, (0).to_string());
+    assert_eq!(ret_2_at_genesis.balances[0].locked, (0).to_string());
 
     // Submit a cellbase tx mined by addr_1, expect to increase the locked balance by 1000 CKB
     let cellbase_tx = RpcTestEngine::build_cellbase_tx(addr_1, 1000);
@@ -120,16 +130,20 @@ fn test_get_ckb_balance_matured_cellbase() {
     engine.append(block_1);
 
     assert_eq!(
-        ret_1_at_genesis[0].unconstrained,
+        ret_1_at_genesis.balances[0].unconstrained,
         (100_142 * BYTE_SHANNONS).to_string()
     );
     let ret_at_block_1 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
-    assert_eq!(ret_at_block_1[0].locked, (1142 * BYTE_SHANNONS).to_string());
+    assert_eq!(
+        ret_at_block_1.balances[0].locked,
+        (1142 * BYTE_SHANNONS).to_string()
+    );
 
     // Submit another cellbase tx mined by addr_2, and set the block epoch bigger than `cellbase_maturity`,
     // expect to:
@@ -143,29 +157,31 @@ fn test_get_ckb_balance_matured_cellbase() {
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
     let ret_2_at_block_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![None],
             address: addr_2.to_string(),
+            block_number: None,
         })
         .unwrap();
 
     assert_eq!(
-        ret_1_at_block_2[0].unconstrained,
+        ret_1_at_block_2.balances[0].unconstrained,
         ((100_142 + 1000) * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_2_at_block_2[0].unconstrained,
+        ret_2_at_block_2.balances[0].unconstrained,
         (100_000 * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_1_at_block_2[0].locked,
+        ret_1_at_block_2.balances[0].locked,
         (142 * BYTE_SHANNONS).to_string()
     );
     assert_eq!(
-        ret_2_at_block_2[0].locked,
+        ret_2_at_block_2.balances[0].locked,
         (1000 * BYTE_SHANNONS).to_string()
     );
 }
@@ -187,17 +203,19 @@ fn test_get_udt_balance() {
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![Some(SUDT_HASH.read().clone())],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![Some(SUDT_HASH.read().clone())],
             address: addr_2.to_string(),
+            block_number: None,
         })
         .unwrap();
 
-    assert_eq!(ret_1[0].unconstrained, 300.to_string());
-    assert_eq!(ret_2[0].unconstrained, 300.to_string());
+    assert_eq!(ret_1.balances[0].unconstrained, 300.to_string());
+    assert_eq!(ret_2.balances[0].unconstrained, 300.to_string());
 }
 
 #[test]
@@ -217,17 +235,19 @@ fn test_get_all_udt_balance() {
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![],
             address: addr_1.to_string(),
+            block_number: None,
         })
         .unwrap();
     let ret_2 = rpc
         .get_balance(GetBalancePayload {
             udt_hashes: hashset![],
             address: addr_2.to_string(),
+            block_number: None,
         })
         .unwrap();
 
-    assert_eq!(ret_1.len(), 2);
-    assert_eq!(ret_2.len(), 2);
+    assert_eq!(ret_1.balances.len(), 2);
+    assert_eq!(ret_2.balances.len(), 2);
 }
 
 #[test]

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -432,16 +432,16 @@ pub struct Operation {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GenericTransaction {
-    pub tx_hash: H256,
-    pub operations: Vec<Operation>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Amount {
     pub value: String,
     pub udt_hash: Option<H256>,
     pub status: Status,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GenericTransaction {
+    pub tx_hash: H256,
+    pub operations: Vec<Operation>,
 }
 
 pub fn details_split_off(

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -432,6 +432,12 @@ pub struct Operation {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GenericTransaction {
+    pub tx_hash: H256,
+    pub operations: Vec<Operation>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Amount {
     pub value: String,
     pub udt_hash: Option<H256>,

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -405,12 +405,14 @@ pub struct SignatureEntry {
     pub index: usize,
     pub group_len: usize,
     pub pub_key: String,
-    pub sig_func: SignatureType,
+    pub sig_type: SignatureType,
 }
 
 impl PartialEq for SignatureEntry {
     fn eq(&self, other: &SignatureEntry) -> bool {
-        self.type_ == other.type_ && self.pub_key == other.pub_key
+        self.type_ == other.type_
+            && self.pub_key == other.pub_key
+            && self.sig_type == other.sig_type
     }
 }
 
@@ -429,13 +431,13 @@ impl Ord for SignatureEntry {
 }
 
 impl SignatureEntry {
-    pub fn new(index: usize, pub_key: String, sig_func: SignatureType) -> Self {
+    pub fn new(index: usize, pub_key: String, sig_type: SignatureType) -> Self {
         SignatureEntry {
             type_: WitnessType::WitnessArgsLock,
             group_len: 1,
             pub_key,
             index,
-            sig_func,
+            sig_type,
         }
     }
 

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -68,13 +68,13 @@ pub enum Status {
 #[repr(u8)]
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SignatureFunc {
+pub enum SignatureType {
     Secp256k1 = 0,
 }
 
-impl Default for SignatureFunc {
+impl Default for SignatureType {
     fn default() -> Self {
-        SignatureFunc::Secp256k1
+        SignatureType::Secp256k1
     }
 }
 
@@ -405,7 +405,7 @@ pub struct SignatureEntry {
     pub index: usize,
     pub group_len: usize,
     pub pub_key: String,
-    pub sig_func: SignatureFunc,
+    pub sig_func: SignatureType,
 }
 
 impl PartialEq for SignatureEntry {
@@ -429,7 +429,7 @@ impl Ord for SignatureEntry {
 }
 
 impl SignatureEntry {
-    pub fn new(index: usize, pub_key: String, sig_func: SignatureFunc) -> Self {
+    pub fn new(index: usize, pub_key: String, sig_func: SignatureType) -> Self {
         SignatureEntry {
             type_: WitnessType::WitnessArgsLock,
             group_len: 1,

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -4,6 +4,7 @@ use common::{anyhow::Result, MercuryError};
 
 use ckb_jsonrpc_types::TransactionView;
 use ckb_types::{bytes::Bytes, core::BlockNumber, packed, prelude::Pack, H256};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
@@ -154,12 +155,23 @@ impl GetBalanceResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Balance {
     pub udt_hash: Option<H256>,
     pub unconstrained: String,
     pub fleeting: String,
     pub locked: String,
+}
+
+impl From<InnerBalance> for Balance {
+    fn from(balance: InnerBalance) -> Self {
+        Balance {
+            udt_hash: balance.udt_hash,
+            unconstrained: balance.unconstrained.to_string(),
+            fleeting: balance.fleeting.to_string(),
+            locked: balance.locked.to_string(),
+        }
+    }
 }
 
 impl Balance {
@@ -169,6 +181,25 @@ impl Balance {
             unconstrained: unconstrained.to_string(),
             fleeting: fleeting.to_string(),
             locked: locked.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct InnerBalance {
+    pub udt_hash: Option<H256>,
+    pub unconstrained: BigUint,
+    pub fleeting: BigUint,
+    pub locked: BigUint,
+}
+
+impl InnerBalance {
+    pub fn new(udt_hash: Option<H256>) -> Self {
+        InnerBalance {
+            udt_hash,
+            unconstrained: 0u8.into(),
+            fleeting: 0u8.into(),
+            locked: 0u8.into(),
         }
     }
 }

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -157,6 +157,7 @@ impl GetBalanceResponse {
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Balance {
+    pub key_address: String,
     pub udt_hash: Option<H256>,
     pub unconstrained: String,
     pub fleeting: String,
@@ -166,6 +167,7 @@ pub struct Balance {
 impl From<InnerBalance> for Balance {
     fn from(balance: InnerBalance) -> Self {
         Balance {
+            key_address: balance.key_address,
             udt_hash: balance.udt_hash,
             unconstrained: balance.unconstrained.to_string(),
             fleeting: balance.fleeting.to_string(),
@@ -175,8 +177,15 @@ impl From<InnerBalance> for Balance {
 }
 
 impl Balance {
-    pub fn new(udt_hash: Option<H256>, unconstrained: u128, fleeting: u128, locked: u128) -> Self {
+    pub fn new(
+        key_address: String,
+        udt_hash: Option<H256>,
+        unconstrained: u128,
+        fleeting: u128,
+        locked: u128,
+    ) -> Self {
         Balance {
+            key_address,
             udt_hash,
             unconstrained: unconstrained.to_string(),
             fleeting: fleeting.to_string(),
@@ -187,6 +196,7 @@ impl Balance {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct InnerBalance {
+    pub key_address: String,
     pub udt_hash: Option<H256>,
     pub unconstrained: BigUint,
     pub fleeting: BigUint,
@@ -194,8 +204,9 @@ pub struct InnerBalance {
 }
 
 impl InnerBalance {
-    pub fn new(udt_hash: Option<H256>) -> Self {
+    pub fn new(key_address: String, udt_hash: Option<H256>) -> Self {
         InnerBalance {
+            key_address,
             udt_hash,
             unconstrained: 0u8.into(),
             fleeting: 0u8.into(),

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -15,7 +15,7 @@ pub const CHEQUE: &str = "cheque";
 pub const SUDT: &str = "sudt_balance";
 
 #[repr(u8)]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Action {
     PayByFrom = 0,
@@ -39,7 +39,7 @@ impl Action {
 }
 
 #[repr(u8)]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Source {
     Unconstrained = 0,
@@ -47,7 +47,7 @@ pub enum Source {
 }
 
 #[repr(u8)]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Status {
     Unconstrained = 0,
@@ -65,7 +65,7 @@ impl Source {
 }
 
 #[repr(u8)]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WitnessType {
     WitnessArgsLock,
@@ -112,14 +112,14 @@ impl ScriptType {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct GetBalancePayload {
     pub udt_hashes: HashSet<Option<H256>>,
     pub block_number: Option<u64>,
     pub address: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GetBalanceResponse {
     pub block_number: u64,
     pub balances: Vec<Balance>,
@@ -134,7 +134,7 @@ impl GetBalanceResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Balance {
     pub udt_hash: Option<H256>,
     pub unconstrained: String,
@@ -153,7 +153,7 @@ impl Balance {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct FromAccount {
     pub idents: Vec<String>,
     pub source: Source,
@@ -168,7 +168,7 @@ impl FromAccount {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ToAccount {
     pub ident: String,
     pub action: Action,
@@ -183,7 +183,7 @@ impl ToAccount {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TransferPayload {
     pub udt_hash: Option<H256>,
     pub from: FromAccount,
@@ -214,21 +214,21 @@ impl TransferPayload {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct CreateWalletPayload {
     pub ident: String,
     pub info: Vec<WalletInfo>,
     pub fee_rate: u64, // shannons/KB
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ScanBlockPayload {
     pub block_number: BlockNumber,
     pub udt_hash: Option<H256>,
     pub idents: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ScanBlockResponse {
     pub inner: Vec<JsonCharge>,
 }
@@ -241,7 +241,7 @@ impl ScanBlockResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct JsonCharge {
     pub address: String,
     pub ckb_amount: String,
@@ -258,7 +258,7 @@ impl From<InnerCharge> for JsonCharge {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct InnerCharge {
     pub address: String,
     pub ckb_amount: u64,
@@ -275,7 +275,7 @@ impl InnerCharge {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct WalletInfo {
     pub udt_hash: H256,
     pub min_ckb: Option<u8>,
@@ -306,7 +306,7 @@ impl WalletInfo {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TransferItem {
     pub to: ToAccount,
     pub amount: u128,
@@ -380,13 +380,13 @@ impl SignatureEntry {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct InnerAccount {
     pub(crate) idents: Vec<String>,
     pub(crate) scripts: Vec<ScriptType>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct InnerTransferItem {
     pub(crate) to: InnerAccount,
     pub(crate) amount: u128,
@@ -408,7 +408,7 @@ impl CellWithData {
 }
 
 // Todo: only remain ckb_all and udt_amount
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DetailedAmount {
     pub udt_amount: u128,
     pub ckb_all: u64,
@@ -428,7 +428,7 @@ impl DetailedAmount {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct InputConsume {
     pub ckb: u64,
     pub udt: u128,
@@ -440,22 +440,22 @@ impl InputConsume {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Operation {
     pub id: u32,
     pub address: String,
-    pub sub_address: Vec<String>,
+    pub sub_address: Option<String>,
     pub amount: Amount,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Amount {
     pub value: String,
     pub udt_hash: Option<H256>,
     pub status: Status,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GenericBlock {
     block_number: BlockNumber,
     block_hash: H256,
@@ -464,7 +464,7 @@ pub struct GenericBlock {
     transactions: Vec<GenericTransaction>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GenericTransaction {
     pub tx_hash: H256,
     pub operations: Vec<Operation>,

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -7,6 +7,7 @@ use ckb_types::{bytes::Bytes, core::BlockNumber, packed, prelude::Pack, H256};
 use serde::{Deserialize, Serialize};
 
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use std::collections::HashSet;
 
 pub const SECP256K1: &str = "secp256k1_blake160";
 pub const ACP: &str = "anyone_can_pay";
@@ -43,6 +44,15 @@ impl Action {
 pub enum Source {
     Unconstrained = 0,
     Fleeting,
+}
+
+#[repr(u8)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Unconstrained = 0,
+    Fleeting,
+    Locked,
 }
 
 impl Source {
@@ -100,6 +110,12 @@ impl ScriptType {
             ScriptType::SUDT => SUDT,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GetBalancePayload {
+    pub udt_hashes: HashSet<Option<H256>>,
+    pub address: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -406,6 +422,20 @@ impl InputConsume {
     pub fn new(ckb: u64, udt: u128) -> Self {
         InputConsume { ckb, udt }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Operation {
+    pub id: u32,
+    pub address: String,
+    pub amount: Amount,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Amount {
+    pub value: String,
+    pub udt_hash: Option<H256>,
+    pub status: Status,
 }
 
 pub fn details_split_off(

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -115,20 +115,36 @@ impl ScriptType {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GetBalancePayload {
     pub udt_hashes: HashSet<Option<H256>>,
+    pub block_number: Option<u64>,
     pub address: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GetBalanceResponse {
+    pub block_number: u64,
+    pub balances: Vec<Balance>,
+}
+
+impl GetBalanceResponse {
+    pub fn new(block_number: u64, balances: Vec<Balance>) -> Self {
+        GetBalanceResponse {
+            block_number,
+            balances,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Balance {
     pub udt_hash: Option<H256>,
     pub unconstrained: String,
     pub fleeting: String,
     pub locked: String,
 }
 
-impl GetBalanceResponse {
+impl Balance {
     pub fn new(udt_hash: Option<H256>, unconstrained: u128, fleeting: u128, locked: u128) -> Self {
-        GetBalanceResponse {
+        Balance {
             udt_hash,
             unconstrained: unconstrained.to_string(),
             fleeting: fleeting.to_string(),
@@ -428,6 +444,7 @@ impl InputConsume {
 pub struct Operation {
     pub id: u32,
     pub address: String,
+    pub sub_address: Vec<String>,
     pub amount: Amount,
 }
 
@@ -436,6 +453,15 @@ pub struct Amount {
     pub value: String,
     pub udt_hash: Option<H256>,
     pub status: Status,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GenericBlock {
+    block_number: BlockNumber,
+    block_hash: H256,
+    parent_block_hash: H256,
+    timestamp: u64,
+    transactions: Vec<GenericTransaction>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -2,7 +2,10 @@
 
 use common::{anyhow::Result, NetworkType};
 use core_extensions::{build_extensions, ExtensionsConfig, CURRENT_EPOCH, MATURE_THRESHOLD};
-use core_rpc::{CkbRpc, CkbRpcClient, MercuryRpc, MercuryRpcImpl, TX_POOL_CACHE, USE_HEX_FORMAT};
+use core_rpc::{
+    CkbRpc, CkbRpcClient, MercuryRpc, MercuryRpcImpl, CURRENT_BLOCK_NUMBER, TX_POOL_CACHE,
+    USE_HEX_FORMAT,
+};
 use core_storage::{BatchStore, RocksdbStore, Store};
 
 use ckb_indexer::indexer::Indexer;
@@ -242,6 +245,7 @@ impl Service {
             }
 
             batch_store.commit().expect("commit should be OK");
+            let _ = *CURRENT_BLOCK_NUMBER.swap(Arc::new(tip));
 
             if prune {
                 let store = BatchStore::create(self.store.clone())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
1. Change the argument of the `get_balance` interface to a struct.
2. Change the `udt_hashes` to a `HashSet`, if it is empty, means to get the balance of all assets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

