### PR TITLE
feat: add script hash extension and register address rpc interface

### DIFF
--- a/core/extensions/src/script_hash/mod.rs
+++ b/core/extensions/src/script_hash/mod.rs
@@ -1,0 +1,68 @@
+pub mod types;
+
+use ckb_types::prelude::Entity;
+pub use types::{Key, KeyPrefix, ScriptHashExtensionError, Value};
+
+use crate::{types::DeployedScriptConfig, Extension};
+
+use common::{anyhow::Result, hash::blake2b_160, NetworkType};
+
+use ckb_indexer::indexer::Indexer;
+use ckb_indexer::store::{Batch, Store};
+use ckb_types::core::{BlockNumber, BlockView};
+use ckb_types::packed;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct ScriptHashExtension<S, BS> {
+    store: S,
+    _indexer: Arc<Indexer<BS>>,
+    _net_ty: NetworkType,
+    _config: HashMap<String, DeployedScriptConfig>,
+}
+
+impl<S: Store, BS: Store> Extension for ScriptHashExtension<S, BS> {
+    fn append(&self, block: &BlockView) -> Result<()> {
+        let mut batch = self.store.batch()?;
+
+        for tx in block.transactions().iter() {
+            for output in tx.outputs().into_iter() {
+                let lock_hash = blake2b_160(output.lock().as_slice());
+                batch.put_kv(Key::ScriptHash(lock_hash), Value::Script(&output.lock()))?;
+            }
+        }
+
+        batch.commit()?;
+        Ok(())
+    }
+
+    fn rollback(&self, _tip_number: BlockNumber, _tip_hash: &packed::Byte32) -> Result<()> {
+        Ok(())
+    }
+
+    fn prune(
+        &self,
+        _tip_number: BlockNumber,
+        _tip_hash: &packed::Byte32,
+        _keep_num: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<S: Store, BS: Store> ScriptHashExtension<S, BS> {
+    pub fn new(
+        store: S,
+        _indexer: Arc<Indexer<BS>>,
+        _net_ty: NetworkType,
+        _config: HashMap<String, DeployedScriptConfig>,
+    ) -> Self {
+        ScriptHashExtension {
+            store,
+            _indexer,
+            _net_ty,
+            _config,
+        }
+    }
+}

--- a/core/extensions/src/script_hash/types.rs
+++ b/core/extensions/src/script_hash/types.rs
@@ -1,0 +1,59 @@
+use common::derive_more::Display;
+
+use ckb_indexer::store;
+use ckb_types::{packed, prelude::Entity};
+
+#[derive(Debug, Display)]
+pub enum ScriptHashExtensionError {
+    #[display(fmt = "DB Error {}", _0)]
+    DBError(String),
+}
+
+impl std::error::Error for ScriptHashExtensionError {}
+
+impl From<store::Error> for ScriptHashExtensionError {
+    fn from(err: store::Error) -> Self {
+        ScriptHashExtensionError::DBError(err.to_string())
+    }
+}
+
+#[repr(u8)]
+pub enum KeyPrefix {
+    ScriptHash = 0,
+}
+
+#[derive(Clone, Debug)]
+pub enum Key {
+    ScriptHash([u8; 20]),
+}
+
+impl Into<Vec<u8>> for Key {
+    fn into(self) -> Vec<u8> {
+        match self {
+            Key::ScriptHash(hash) => {
+                let mut encoded = vec![KeyPrefix::ScriptHash as u8];
+                encoded.extend_from_slice(&hash);
+                encoded
+            }
+        }
+    }
+}
+
+impl Key {
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Value<'a> {
+    Script(&'a packed::Script),
+}
+
+impl<'a> Into<Vec<u8>> for Value<'a> {
+    fn into(self) -> Vec<u8> {
+        match self {
+            Value::Script(script) => script.as_slice().to_vec(),
+        }
+    }
+}

--- a/core/extensions/src/tests/mod.rs
+++ b/core/extensions/src/tests/mod.rs
@@ -9,9 +9,10 @@ pub use memory_store::MemoryDB;
 use crate::types::{DeployedScriptConfig, ExtensionsConfig};
 use crate::{
     ckb_balance::CkbBalanceExtension, lock_time::LocktimeExtension,
-    rce_validator::RceValidatorExtension, special_cells::SpecialCellsExtension,
-    udt_balance::UDTBalanceExtension, BoxedExtension, ExtensionType, CKB_EXT_PREFIX,
-    LOCK_TIME_PREFIX, RCE_EXT_PREFIX, SP_CELL_EXT_PREFIX, UDT_EXT_PREFIX,
+    rce_validator::RceValidatorExtension, script_hash::ScriptHashExtension,
+    special_cells::SpecialCellsExtension, udt_balance::UDTBalanceExtension, BoxedExtension,
+    ExtensionType, CKB_EXT_PREFIX, LOCK_TIME_PREFIX, RCE_EXT_PREFIX, SCRIPT_HASH_EXT_PREFIX,
+    SP_CELL_EXT_PREFIX, UDT_EXT_PREFIX,
 };
 
 use core_storage::{BatchStore, PrefixStore};
@@ -170,6 +171,13 @@ pub fn build_extension<S: Store + 'static>(
 
         ExtensionType::Locktime => Box::new(LocktimeExtension::new(
             PrefixStore::new_with_prefix(batch_store, Bytes::from(*LOCK_TIME_PREFIX)),
+            Arc::clone(&indexer),
+            NETWORK_TYPE,
+            script_config,
+        )),
+
+        ExtensionType::ScriptHash => Box::new(ScriptHashExtension::new(
+            PrefixStore::new_with_prefix(batch_store, Bytes::from(*SCRIPT_HASH_EXT_PREFIX)),
             Arc::clone(&indexer),
             NETWORK_TYPE,
             script_config,

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -20,7 +20,7 @@ use common::anyhow::Result;
 
 use async_trait::async_trait;
 use ckb_jsonrpc_types::{BlockView, LocalNode, RawTxPool, TransactionWithStatus};
-use ckb_types::{core::BlockNumber, H256};
+use ckb_types::{core::BlockNumber, H160, H256};
 use jsonrpc_core::Result as RpcResult;
 use jsonrpc_derive::rpc;
 
@@ -46,6 +46,9 @@ pub trait MercuryRpc {
 
     #[rpc(name = "get_transaction_history")]
     fn get_transaction_history(&self, ident: String) -> RpcResult<Vec<TransactionWithStatus>>;
+
+    #[rpc(name = "register_addresses")]
+    fn register_addresses(&self, addresses: Vec<String>) -> RpcResult<Vec<H160>>;
 
     #[rpc(name = "scan_deposit")]
     fn scan_deposit(&self, payload: ScanBlockPayload) -> RpcResult<ScanBlockResponse>;

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -48,7 +48,7 @@ pub trait MercuryRpc {
     fn get_transaction_history(&self, ident: String) -> RpcResult<Vec<TransactionWithStatus>>;
 
     #[rpc(name = "register_addresses")]
-    fn register_addresses(&self, addresses: Vec<String>) -> RpcResult<Vec<H160>>;
+    fn register_addresses(&self, normal_addresses: Vec<String>) -> RpcResult<Vec<H160>>;
 
     #[rpc(name = "scan_deposit")]
     fn scan_deposit(&self, payload: ScanBlockPayload) -> RpcResult<ScanBlockResponse>;

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -134,7 +134,7 @@ where
             .map_err(|e| Error::invalid_params(e.to_string()))
     }
 
-    fn register_addresses(&self, addresses: Vec<String>) -> RpcResult<Vec<H160>> {
+    fn register_addresses(&self, normal_addresses: Vec<String>) -> RpcResult<Vec<H160>> {
         let mut ret = Vec::new();
         let mut batch = rpc_try!(self.store.batch());
 

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -139,7 +139,7 @@ where
         let mut batch = rpc_try!(self.store.batch());
 
         // Todo: refactor this.
-        for addr in addresses.iter() {
+        for addr in normal_addresses.iter() {
             let script = address_to_script(Address::from_str(addr).unwrap().payload());
             let script_hash = blake2b_160(script.as_slice());
             let key = add_prefix(

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -12,8 +12,10 @@ use common::{
     hash::blake2b_160, utils::parse_address, Address, AddressPayload, CodeHashIndex, MercuryError,
     NetworkType,
 };
-use core_extensions::{rce_validator, DeployedScriptConfig, RCE_EXT_PREFIX};
-use core_storage::add_prefix;
+use core_extensions::{
+    rce_validator, script_hash, DeployedScriptConfig, RCE_EXT_PREFIX, SCRIPT_HASH_EXT_PREFIX,
+};
+use core_storage::{add_prefix, Batch};
 
 use arc_swap::ArcSwap;
 use ckb_indexer::{indexer::DetailedLiveCell, store::Store};
@@ -130,6 +132,28 @@ where
         log::debug!("get transaction history ident {:?}", ident);
         self.inner_get_transaction_history(ident)
             .map_err(|e| Error::invalid_params(e.to_string()))
+    }
+
+    fn register_addresses(&self, addresses: Vec<String>) -> RpcResult<Vec<H160>> {
+        let mut ret = Vec::new();
+        let mut batch = rpc_try!(self.store.batch());
+
+        // Todo: refactor this.
+        for addr in addresses.iter() {
+            let script = address_to_script(Address::from_str(addr).unwrap().payload());
+            let script_hash = blake2b_160(script.as_slice());
+            let key = add_prefix(
+                *SCRIPT_HASH_EXT_PREFIX,
+                script_hash::Key::ScriptHash(script_hash).into_vec(),
+            );
+
+            rpc_try!(batch.put_kv(key, script_hash::Value::Script(&script)));
+            ret.push(H160(script_hash));
+        }
+
+        rpc_try!(batch.commit());
+
+        Ok(ret)
     }
 
     fn scan_deposit(&self, payload: ScanBlockPayload) -> RpcResult<ScanBlockResponse> {

--- a/core/rpc/src/tests/operation.rs
+++ b/core/rpc/src/tests/operation.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[test]
+fn test_ckb_transfer_complete() {
+    let addr_1 = "ckt1qyqr79tnk3pp34xp92gerxjc4p3mus2690psf0dd70";
+    let addr_2 = "ckt1qyq2y6jdkynen2vx946tnsdw2dgucvv7ph0s8n4kfd";
+
+    let script_1 = address_to_script(parse_address(addr_1).unwrap().payload());
+    let script_2 = address_to_script(parse_address(addr_2).unwrap().payload());
+    let script_1_hash = blake2b_160(script_1.as_slice());
+    let script_2_hash = blake2b_160(script_2.as_slice());
+
+    let engine = RpcTestEngine::init_data(vec![AddressData::new(addr_1, 500_000, 0, 0, 0)]);
+
+    let rpc = engine.rpc();
+
+    let exist = engine
+        .get_db()
+        .exists(add_prefix(
+            *SCRIPT_HASH_EXT_PREFIX,
+            script_hash::Key::ScriptHash(script_1_hash).into_vec(),
+        ))
+        .unwrap();
+
+    assert!(exist);
+
+    let exist = engine
+        .get_db()
+        .exists(add_prefix(
+            *SCRIPT_HASH_EXT_PREFIX,
+            script_hash::Key::ScriptHash(script_2_hash).into_vec(),
+        ))
+        .unwrap();
+
+    assert!(!exist);
+
+    let hash = rpc.register_addresses(vec![addr_2.to_string()]).unwrap();
+    assert_eq!(H160(script_2_hash), hash[0]);
+
+    let exist = engine
+        .get_db()
+        .exists(add_prefix(
+            *SCRIPT_HASH_EXT_PREFIX,
+            script_hash::Key::ScriptHash(script_2_hash).into_vec(),
+        ))
+        .unwrap();
+
+    assert!(exist);
+}

--- a/devtools/config/mainnet_config.toml
+++ b/devtools/config/mainnet_config.toml
@@ -22,7 +22,10 @@ ckb_uri = "http://127.0.0.1:8114"
 
 listen_uri = "0.0.0.0:8116"
 
-# The secp256k1_blake160 script info is indispensable.
+[[extensions_config]]
+extension_name = "script_hash"
+scripts = []
+
 [[extensions_config]]
 extension_name = "ckb_balance"
 

--- a/devtools/config/testnet_config.toml
+++ b/devtools/config/testnet_config.toml
@@ -22,7 +22,10 @@ ckb_uri = "http://127.0.0.1:8114"
 
 listen_uri = "0.0.0.0:8116"
 
-# The secp256k1_blake160 script info is indispensable.
+[[extensions_config]]
+extension_name = "script_hash"
+scripts = []
+
 [[extensions_config]]
 extension_name = "ckb_balance"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
1. Add script hash extension to index any script with its blake160 hash in output.
2. Add register address RPC interface.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

