### PR TITLE
feat(rpc): building tx output support witnesses filling and new signature actions

### DIFF
--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -139,9 +139,6 @@ pub enum RpcErrorMessage {
 
     #[display(fmt = "Overflow")]
     Overflow,
-
-    #[display(fmt = "Missing input witness")]
-    MissingInputWitness,
 }
 
 impl std::error::Error for RpcErrorMessage {}
@@ -170,7 +167,6 @@ impl RpcErrorMessage {
             RpcErrorMessage::MissingScriptInfo(_) => -11020,
             RpcErrorMessage::InvalidScriptHash(_) => -11021,
             RpcErrorMessage::ParseAddressError(_) => -11022,
-            RpcErrorMessage::MissingInputWitness => -11023,
 
             RpcErrorMessage::MissingConsumedInfo => -11020,
 

--- a/core/rpc/src/rpc_impl.rs
+++ b/core/rpc/src/rpc_impl.rs
@@ -12,7 +12,7 @@ pub use crate::rpc_impl::consts::{
 };
 
 use crate::error::{RpcError, RpcErrorMessage, RpcResult};
-use crate::rpc_impl::build_tx::calculate_tx_size_with_witness_placeholder;
+use crate::rpc_impl::build_tx::calculate_tx_size;
 use crate::types::{
     indexer, indexer_legacy, AdjustAccountPayload, BlockInfo, DepositPayload, GetBalancePayload,
     GetBalanceResponse, GetBlockInfoPayload, GetSpentTransactionPayload,

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -140,12 +140,6 @@ pub enum TxView {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum WitnessType {
-    WitnessLock,
-    WitnessType,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum DaoState {
     Deposit(BlockNumber),
     // first is deposit block number and last is withdraw block number


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
This pr redefines SignatureAction and fills in the witnesses part of all built transaction. Mercury supports the feature of filling witnesses, so that some more special transactions can be built, such as transactions that need to fill special data for witnesses (such as WitnessArgs::input_type). The redefinition of SignatureAction ensures that the external SDK side has enough information to sign.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

Breaking Change: 

```rust
pub struct TransactionCompletionResponse {
    pub tx_view: TransactionView,
    pub signature_actions: Vec<SignatureAction>,
}
```

**Special notes for your reviewer**:

