### PR TITLE
refactor(SQL): add semicolons which prevent successful execution of SQL

### DIFF
--- a/devtools/create_table/create_sqlite_table.sql
+++ b/devtools/create_table/create_sqlite_table.sql
@@ -99,7 +99,7 @@ CREATE TABLE mercury_indexer_cell(
     type_code_hash blob,
     type_args blob,
     type_script_type smallint
-)
+);
 
 CREATE TABLE mercury_script(
     id bigint PRIMARY KEY,

--- a/devtools/create_table/create_table.sql
+++ b/devtools/create_table/create_table.sql
@@ -98,7 +98,7 @@ CREATE TABLE mercury_indexer_cell(
     type_code_hash bytea,
     type_args bytea,
     type_script_type smallint
-)
+);
 
 CREATE TABLE mercury_script(
     script_hash bytea NOT NULL PRIMARY KEY,


### PR DESCRIPTION
**What this PR does / why we need it**:

Two of the SQL files are missing semicolons that cause execution failure. This PR is to add the missing semicolons.
