### PR TITLE
refactor(sync): change build indexer cell table process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "rbatis"
-version = "2.1.8"
+version = "2.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79dd9b70a719578b447df129a547d02107aebb34ce3efc9a085915f20b9e527d"
+checksum = "75bffaf693d7c3e8482ce343584181fd228bf5e5f231d177952bf6460f8b4453"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4161,9 +4161,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -4178,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4199,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4211,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-attributes"
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c2722795460108a7872e1cd933a85d6ec38abc4baecad51028f702da28889f"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
 dependencies = [
  "crc-catalog",
 ]
@@ -2096,7 +2096,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0109c4f972058f3b1925b73a17210aff7b63b65967264d0045d15ee88fe84f0c"
 dependencies = [
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "beef",
  "futures-channel",
  "futures-util",
@@ -3141,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "rbatis"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217abf31232ce83ac516995d5afa2ffa7c3b829a0216841ae013e1ecd2c5866d"
+checksum = "79dd9b70a719578b447df129a547d02107aebb34ce3efc9a085915f20b9e527d"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 core-cli = { path = "core/cli" }
 log = "0.4"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "cargo_bench_support"] }

--- a/apm/tracing/Cargo.toml
+++ b/apm/tracing/Cargo.toml
@@ -12,4 +12,4 @@ lazy_static = "1.4"
 minitrace = { git = "https://github.com/tikv/minitrace-rust.git" }
 minitrace-jaeger = { git = "https://github.com/tikv/minitrace-rust.git" }
 minitrace-macro = { git = "https://github.com/tikv/minitrace-rust.git" }
-tokio = { version = "1.12", features = ["rt", "sync"] }
+tokio = { version = "1.13", features = ["rt", "sync"] }

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 log4rs = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.12", features = ["time"] }
+tokio = { version = "1.13", features = ["time"] }
 toml = "0.5"
 
 common = { path = "../../common" }

--- a/core/inspection/Cargo.toml
+++ b/core/inspection/Cargo.toml
@@ -10,7 +10,7 @@ ckb-jsonrpc-types = "0.101"
 ckb-types = "0.101"
 hex = "0.4"
 log = "0.4"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
 
 common = { path = "../../common" }
 core-storage = { path = "../storage" }

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.11"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
 
 jsonrpsee-http-server = "0.4"
 jsonrpsee-proc-macros = "0.4"

--- a/core/rpc/src/ckb_client.rs
+++ b/core/rpc/src/ckb_client.rs
@@ -38,11 +38,16 @@ pub struct CkbRpcClient {
 impl SyncAdapter for CkbRpcClient {
     async fn pull_blocks(&self, block_numbers: Vec<BlockNumber>) -> Result<Vec<core::BlockView>> {
         let mut ret = Vec::new();
-        for block in self.get_blocks_by_number(block_numbers).await?.iter() {
+        for (idx, block) in self
+            .get_blocks_by_number(block_numbers.clone())
+            .await?
+            .iter()
+            .enumerate()
+        {
             if let Some(b) = block {
                 ret.push(core::BlockView::from(b.to_owned()));
             } else {
-                return Err(RpcErrorMessage::GetNoneBlockFromNode.into());
+                log::error!("[sync] Get none block {:?} from node", block_numbers[idx]);
             }
         }
 

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -377,6 +377,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             };
             objects.push(object);
         }
+
         Ok(indexer::PaginationResponse {
             objects,
             last_cursor: db_response.next_cursor,

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -15,7 +15,7 @@ jsonrpsee-proc-macros = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time"] }
 
 common = { path = "../../common" }
 core-extensions = { path = "../extensions" }

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 rbatis = { version = "2.1", features = ["all-database", "tokio1"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 common = { path = "../../common" }

--- a/core/storage/src/relational/insert.rs
+++ b/core/storage/src/relational/insert.rs
@@ -94,13 +94,13 @@ impl RelationalStorage {
         save_batch_slice!(tx, tx_set, output_cell_set, live_cell_set, script_batch);
 
         self.update_consumed_cells(&consumed_infos, tx).await?;
-        self.fill_and_save_indexer_cells(block_number, indexer_cells, &consumed_infos, tx)
-            .await?;
+        // self.fill_and_save_indexer_cells(block_number, indexer_cells, &consumed_infos, tx)
+        //     .await?;
 
         Ok(())
     }
 
-    async fn fill_and_save_indexer_cells(
+    async fn _fill_and_save_indexer_cells(
         &self,
         block_number: u64,
         mut indexer_cells: Vec<IndexerCellTable>,

--- a/core/synchronization/Cargo.toml
+++ b/core/synchronization/Cargo.toml
@@ -18,7 +18,7 @@ rlp = "0.5"
 parking_lot = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.12", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 common = { path = "../../common" }
 core-storage = { path = "../storage" }

--- a/core/synchronization/src/lib.rs
+++ b/core/synchronization/src/lib.rs
@@ -428,6 +428,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_build_indexer_table() {
         // env_logger::builder().filter_level(log::LevelFilter::Debug).init();

--- a/db/xsql/src/lib.rs
+++ b/db/xsql/src/lib.rs
@@ -38,7 +38,9 @@ impl XSQLPool {
     pub fn new(max_connections: u32, center_id: u16, node_id: u16, log_level: LevelFilter) -> Self {
         let config = DBPoolOptions {
             max_connections,
-            idle_timeout: Some(Duration::from_secs(1)),
+            min_connections: 2,
+            idle_timeout: Some(Duration::from_secs(3)),
+            test_before_acquire: false,
             ..Default::default()
         };
 

--- a/devtools/create_table/create_table.sql
+++ b/devtools/create_table/create_table.sql
@@ -153,5 +153,11 @@ CREATE INDEX "index_cell_table_type_hash" ON "public"."mercury_cell" ("type_hash
 CREATE INDEX "index_cell_table_lock_code_hash_and_lock_script_type" ON "public"."mercury_cell" ("lock_code_hash", "lock_script_type");
 CREATE INDEX "index_cell_table_type_code_hash_and_type_script_type" ON "public"."mercury_cell" ("type_code_hash", "type_script_type");
 CREATE INDEX "index_cell_table_consume_tx_hash_and_consumed_tx_index" ON "public"."mercury_cell" ("consumed_tx_hash", "consumed_tx_index");
+CREATE INDEX "index_cell_table_block_number" ON "public"."mercury_cell" USING btree (
+  "block_number" "pg_catalog"."int4_ops" ASC NULLS LAST
+);
+CREATE INDEX "index_cell_table_consumed_block_number" ON "public"."mercury_cell" USING btree (
+  "consumed_block_number" "pg_catalog"."int8_ops" ASC NULLS LAST
+);
 
 CREATE INDEX "index_transaction_table_tx_hash" ON "mercury_transaction" USING btree ("tx_hash" "pg_catalog"."bytea_ops" ASC NULLS LAST);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
1. Add build index SQL of `block_number` and `consumed_block_number` in `mercury_cell` table.
2. After building the indexer cells of the corresponding block number range, insert them into the database immediately.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

