### PR TITLE
fix(rpc): Fix signature_actions in build_adjust_account_transaction

### DIFF
--- a/core/rpc/src/rpc_impl/adjust_account.rs
+++ b/core/rpc/src/rpc_impl/adjust_account.rs
@@ -291,14 +291,16 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         )
         .to_string();
         let mut signature_actions = HashMap::new();
-        utils::add_signature_action(
-            address,
-            inputs[0].cell_output.calc_lock_hash().to_string(),
-            SignAlgorithm::Secp256k1,
-            HashAlgorithm::Blake2b,
-            &mut signature_actions,
-            0,
-        );
+        for (i, input) in inputs.iter().enumerate() {
+            utils::add_signature_action(
+                address.clone(),
+                input.cell_output.calc_lock_hash().to_string(),
+                SignAlgorithm::Secp256k1,
+                HashAlgorithm::Blake2b,
+                &mut signature_actions,
+                i,
+            );
+        }
 
         let inputs = inputs
             .iter()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Fix signature_actions in build_adjust_account_transaction, other_indexes_in_group is empty when inputs are more than one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

