### PR TITLE
fix(rpc): pool duplicate cells

### DIFF
--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -516,6 +516,7 @@ In CKB, users must create asset accounts for receiving UDT assets. Each account 
   - If `item` is the ID of a record, the account controlled by the identity that is behind the record will be created or recycled.
 - `from` - Specify the object for providing CKB for creating asset accounts.
   - If `from` is null, the method obtains CKB from `item`.
+  - The elements in the `from` array must be the same kind of enumeration.
 - `asset_info` - Specify an asset type for creating asset accounts.
 - `account_number` - Specify a target account number.
 - `extra_ckb` - Specify the amount of extra CKB injected into an account for paying fees or other usage.
@@ -667,6 +668,8 @@ To build a raw transfer transaction and signature actions for signing.
 
 - `asset_info` - Specify the asset type for the transfer.
 - `from` - Specify the sender.
+  - The elements in the `From::items` array must be the same kind of enumeration.
+
 - `to` - Specify recipient's address, amount etc.
 - `pay_fee` - Specify the account for paying the fee.
   - If `pay_fee` is null, the `from` address pays the fee.
@@ -818,7 +821,7 @@ To build a raw transfer transaction and signature actions for signing, and infer
 **Params**
 
 - `asset_info` - Specify the asset type for the transfer.
-- `from` - Specify the sender.
+- `from` - Specify the senders' addresses. 
 - `to` - Specify recipient's address and amount.
 - `change` -  Specify an address for the change.
   - If `change` is null, the first address in `from` works as the change address.
@@ -1059,6 +1062,8 @@ To build a transaction to deposit specified amount of CKB to Dao.
 **Params**
 
 - `from` - Specify the provider of the CKB for Dao deposition.
+  - The elements in the `From::items` array must be the same kind of enumeration.
+
 - `to` - Specify the recipient of the deposit.
   - If `to` is null, the CKB is deposited to the `from` address.
 - `amount` - Specify the amount of CKB for the deposit. The deposit amount should larger than 200 CKB.
@@ -1897,7 +1902,7 @@ Field
 
 Fields
 
-- `item`  (Type: `Array<`[`Identity`](#type-identity)`|`[`Address`](#type-address)`|`[`RecordId`](#type-recordid)`>`): Specify the object that pools the assets.
+- `items`  (Type: `Array<`[`Identity`](#type-identity)`|`[`Address`](#type-address)`|`[`RecordId`](#type-recordid)`>`): Specify the object that pools the assets.
   - If `item` is an identity, the assets of addresses controlled by the identity will be pooled.
   - If `item` is an address, the assets of unspent records of the address will be pooled.
   - If `item` is the ID of an unspent record, the assets of the record will be pooled.

--- a/core/rpc/src/error.rs
+++ b/core/rpc/src/error.rs
@@ -139,6 +139,9 @@ pub enum RpcErrorMessage {
 
     #[display(fmt = "Overflow")]
     Overflow,
+
+    #[display(fmt = "The input items must be the same kind of enumeration")]
+    ItemsNotSameEnumValue,
 }
 
 impl std::error::Error for RpcErrorMessage {}
@@ -167,6 +170,7 @@ impl RpcErrorMessage {
             RpcErrorMessage::MissingScriptInfo(_) => -11020,
             RpcErrorMessage::InvalidScriptHash(_) => -11021,
             RpcErrorMessage::ParseAddressError(_) => -11022,
+            RpcErrorMessage::ItemsNotSameEnumValue => -11023,
 
             RpcErrorMessage::MissingConsumedInfo => -11020,
 

--- a/core/rpc/src/rpc_impl/adjust_account.rs
+++ b/core/rpc/src/rpc_impl/adjust_account.rs
@@ -31,6 +31,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if payload.asset_info.asset_type == AssetType::CKB {
             return Err(RpcErrorMessage::AdjustAccountOnCkb);
         }
+        utils::check_same_enum_value(payload.from.iter().collect())?;
 
         let account_number = payload.account_number.unwrap_or(1) as usize;
         let extra_ckb = payload.extra_ckb.unwrap_or_else(|| ckb(1));

--- a/core/rpc/src/rpc_impl/build_tx.rs
+++ b/core/rpc/src/rpc_impl/build_tx.rs
@@ -54,10 +54,13 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if payload.amount < MIN_DAO_CAPACITY {
             return Err(RpcErrorMessage::InvalidDAOCapacity);
         }
+        utils::check_same_enum_value(payload.from.items.iter().collect())?;
+        let mut payload = payload;
+        payload.from.items = utils::dedup_json_items(payload.from.items);
 
         self.build_transaction_with_adjusted_fee(
             Self::prebuild_dao_deposit_transaction,
-            ctx.clone(),
+            ctx,
             payload.clone(),
             payload.fee_rate,
         )
@@ -144,7 +147,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
     ) -> InnerResult<TransactionCompletionResponse> {
         self.build_transaction_with_adjusted_fee(
             Self::prebuild_dao_withdraw_transaction,
-            ctx.clone(),
+            ctx,
             payload.clone(),
             payload.fee_rate,
         )
@@ -513,6 +516,9 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if payload.from.items.len() > MAX_ITEM_NUM || payload.to.to_infos.len() > MAX_ITEM_NUM {
             return Err(RpcErrorMessage::ExceedMaxItemNum);
         }
+        utils::check_same_enum_value(payload.from.items.iter().collect())?;
+        let mut payload = payload;
+        payload.from.items = utils::dedup_json_items(payload.from.items);
 
         for to_info in &payload.to.to_infos {
             match u128::from_str(&to_info.amount) {
@@ -531,7 +537,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         self.build_transaction_with_adjusted_fee(
             Self::prebuild_transfer_transaction,
-            ctx.clone(),
+            ctx,
             payload.clone(),
             payload.fee_rate,
         )
@@ -1246,16 +1252,9 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         ctx: Context,
         payload: SimpleTransferPayload,
     ) -> InnerResult<TransactionCompletionResponse> {
-        if payload.from.is_empty() || payload.to.is_empty() {
-            return Err(RpcErrorMessage::NeedAtLeastOneFromAndOneTo);
-        }
-        if payload.from.len() > MAX_ITEM_NUM || payload.to.len() > MAX_ITEM_NUM {
-            return Err(RpcErrorMessage::ExceedMaxItemNum);
-        }
-
         self.build_transaction_with_adjusted_fee(
             Self::prebuild_simple_transfer_transaction,
-            ctx.clone(),
+            ctx,
             payload.clone(),
             payload.fee_rate,
         )
@@ -1271,7 +1270,6 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if payload.from.is_empty() || payload.to.is_empty() {
             return Err(RpcErrorMessage::NeedAtLeastOneFromAndOneTo);
         }
-
         if payload.from.len() > MAX_ITEM_NUM || payload.to.len() > MAX_ITEM_NUM {
             return Err(RpcErrorMessage::ExceedMaxItemNum);
         }
@@ -1281,6 +1279,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             let identity = address_to_identity(address)?;
             from_items.push(JsonItem::Identity(identity.encode()));
         }
+        from_items = utils::dedup_json_items(from_items);
 
         let mut to_items = vec![];
         for ToInfo { address, .. } in &payload.to {

--- a/core/rpc/src/rpc_impl/build_tx.rs
+++ b/core/rpc/src/rpc_impl/build_tx.rs
@@ -3,7 +3,7 @@ use crate::rpc_impl::utils::address_to_identity;
 use crate::rpc_impl::{
     address_to_script, utils, ACP_CODE_HASH, BYTE_SHANNONS, CHEQUE_CELL_CAPACITY, CHEQUE_CODE_HASH,
     CURRENT_EPOCH_NUMBER, DEFAULT_FEE_RATE, INIT_ESTIMATE_FEE, MAX_ITEM_NUM, MIN_CKB_CAPACITY,
-    MIN_DAO_CAPACITY, STANDARD_SUDT_CAPACITY,
+    MIN_DAO_CAPACITY, SECP256K1_CODE_HASH, STANDARD_SUDT_CAPACITY,
 };
 use crate::types::{
     AddressOrLockHash, AssetInfo, AssetType, DaoClaimPayload, DaoDepositPayload,
@@ -215,7 +215,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                 asset_ckb_set.clone(),
                 None,
                 None,
-                None,
+                Some((**SECP256K1_CODE_HASH.load()).clone()),
                 Some(ExtraType::Dao),
                 false,
             )
@@ -349,7 +349,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                 asset_ckb_set.clone(),
                 None,
                 None,
-                None,
+                Some((**SECP256K1_CODE_HASH.load()).clone()),
                 Some(ExtraType::Dao),
                 false,
             )

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -191,7 +191,7 @@ impl std::convert::TryFrom<JsonItem> for Item {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum JsonItem {
     Identity(String),
     Address(String),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

In Mercury 0.2.0 (beta3 and before), the pool_live_cells_by_items method will output duplicate cells in the following situations:

- Input parameter items: Vec, there are duplicate items;
- Input parameter items: Vec, while mixing Identity, Address and Record, at this time they may parse out duplicate lock hash for cell search
- Inside pool_live_cells_by_items: pool normal_ckb_cells logic includes pool cell_base_cells. When there is a "miner" item in the input parameter, duplicate cells will be output

In this PR:

- At the entrance of the rpc interface, perform deduplication of items> and check the same type of enumeration (that is, all are Identity, or all are Address, or all are Record)
  - Involved rpc: build_adjust_account_transaction (AdjustAccountPayload::from::HashSet<JsonItem>)
  - Involved rpc: build_transfer_transaction (TransferPayload::From::Vec<JsonItem>)
  - Involved rpc: build_smart_transfer_transaction (SmartTransferPayload::from::Vec<String>)
  - Involved rpc: build_dao_deposit_transaction (DaoDepositPayload::From::Vec<JsonItem>)
- Repair the logic of pool normal_ckb_cells inside pool_live_cells_by_items

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

