### PR TITLE
feat(rpc): add timestamp to TransactionInfo.

### DIFF
--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -1799,6 +1799,7 @@ Fields
 - `records`  (Type: `Array<`[`Record`](#type-record)`>`): Specify the records in the transaction.
 - `fee` (Type: `Uint64`):  Specify the fee for the transaction.
 - `burn` (Type: `Array<`[`BurnInfo`](#type-burninfo)`>`): Specify the amount of burned UDT assets in the transaction.
+- `timestamp`(Type: `Uint64`): Specifies the timestamp of the block in which the transaction is packaged.
 
 ### Type `Record`
 
@@ -1813,7 +1814,7 @@ Fields
 - `asset_type` (Type: [`AssetInfo`](#type-assetinfo)): Specify the asset type of the record.
 - `status` (Type: [`Claimable`](#type-claimable)`|`[`Fixed`](#type-fixed)):  Specify the status of the record.
 - `extra` (Type:  [`DaoInfo`](#type-daoinfo)`|"Cellbase"|null`): Specify extra information of the record.
-- `epoch_number` (Type: `u64`): Epoch value encoded to u64.
+- `epoch_number` (Type: `Uint64`): Epoch value encoded.
 
 ### Type `Claimable`
 

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -674,6 +674,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                     amount: (-amount).to_string(),
                 })
                 .collect(),
+            timestamp: tx_wrapper.timestamp,
         })
     }
 

--- a/core/rpc/src/types.rs
+++ b/core/rpc/src/types.rs
@@ -318,6 +318,7 @@ pub struct TransactionInfo {
     pub records: Vec<Record>,
     pub fee: i64,
     pub burn: Vec<BurnInfo>,
+    pub timestamp: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]

--- a/core/storage/src/relational/fetch.rs
+++ b/core/storage/src/relational/fetch.rs
@@ -297,12 +297,15 @@ impl RelationalStorage {
                     None => vec![],
                 };
 
+                let timestamp = tx.tx_timestamp;
+
                 TransactionWrapper {
                     transaction_with_status,
                     transaction_view,
                     input_cells,
                     output_cells,
                     is_cellbase,
+                    timestamp,
                 }
             })
             .collect();

--- a/db/protocol/src/lib.rs
+++ b/db/protocol/src/lib.rs
@@ -126,4 +126,5 @@ pub struct TransactionWrapper {
     pub input_cells: Vec<DetailedCell>,
     pub output_cells: Vec<DetailedCell>,
     pub is_cellbase: bool,
+    pub timestamp: u64,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

When rpc `query_transactions` is called, the time stamp information will be newly added to the returned TransactionInfo.

```rust
pub struct TransactionInfo {
    ...
    pub timestamp: u64, 
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

