### PR TITLE
feat(rpc): add timestamp for rpc query_transactions when native type

### DIFF
--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -376,7 +376,7 @@ To return the double-entry style transaction along with the status of a specifie
   - `pagination`: [`PaginationRequest`](#type-paginationrequest)
   - `structure_type`: `"Native"|"DoubleEntry"`
 - result
-  - `response`: `Array<`[`TransactionInfo`](#type-transactioninfo)`|`[`TransactionWithStatus`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-transactionwithstatus)`>`
+  - `response`: `Array<`[`TransactionInfo`](#type-transactioninfo)`|`[`TransactionWithRichStatus`](#type-transactionwithrichstatus)`>`
   - `next_cursor`: `string|null`
   - `total_count`: `Uint64|null`
 
@@ -473,7 +473,8 @@ To return generic transactions and pagination settings from practical searching.
               "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd",
               "amount": "0"
             }
-          ]
+          ],
+          "timestamp": 1631977498936
         }
       }
     ],
@@ -1799,7 +1800,27 @@ Fields
 - `records`  (Type: `Array<`[`Record`](#type-record)`>`): Specify the records in the transaction.
 - `fee` (Type: `Uint64`):  Specify the fee for the transaction.
 - `burn` (Type: `Array<`[`BurnInfo`](#type-burninfo)`>`): Specify the amount of burned UDT assets in the transaction.
-- `timestamp`(Type: `Uint64`): Specifies the timestamp of the block in which the transaction is packaged.
+- `timestamp` (Type: `Uint64`): Specify the timestamp of the block in which the transaction is packaged.
+
+### Type `TransactionWithRichStatus`
+
+A native style transaction structure.
+
+Fields
+
+- `transaction` (Type: [`TransactionView`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-transactionview) `|` `null` ): Specify the transaction.
+- `tx_status` (Type: [`TxRichStatus`](#type-txrichstatus)): Specify the transaction status.
+
+### Type `TxRichStatus`
+
+Transaction rich status.
+
+Fields
+
+- `status` (Type: [`Status`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-status)): The transaction status, allowed values: "pending", "proposed" "committed" "unknown" and "rejected".
+- `block_hash` (Type: [`H256`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-h256) `|` `null`): Specify the block hash of the block which has committed this transaction in the canonical chain.
+- `reason` (Type: `string` `|` `null`): Specify the reason why the transaction is rejected.
+- `timestamp` (Type: `Uint64` `|` `null`): Specify the timestamp of the block in which the transaction is packaged.
 
 ### Type `Record`
 

--- a/core/rpc/src/rpc_impl/query.rs
+++ b/core/rpc/src/rpc_impl/query.rs
@@ -12,13 +12,13 @@ use common::utils::parse_address;
 use common::{Context, Order, PaginationRequest, PaginationResponse, Range, SECP256K1};
 use common_logger::tracing_async;
 use core_storage::{DBInfo, Storage};
+use protocol::TransactionWrapper;
 
 use ckb_jsonrpc_types::{self, Capacity, Script, Uint64};
 use ckb_types::{bytes::Bytes, packed, prelude::*, H160, H256};
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 
-use protocol::TransactionWrapper;
 use std::collections::{HashMap, HashSet};
 use std::{convert::TryInto, iter::Iterator, str::FromStr};
 
@@ -189,7 +189,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                 response: pagination_ret
                     .response
                     .into_iter()
-                    .map(|tx_wrapper| TxView::TransactionView(tx_wrapper.transaction_with_status))
+                    .map(|tx_wrapper| TxView::TransactionView(tx_wrapper.into()))
                     .collect(),
                 next_cursor: pagination_ret.next_cursor,
                 count: pagination_ret.count,
@@ -278,7 +278,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                 let tx = self
                     .inner_get_transaction_with_status(ctx.clone(), tx_hash)
                     .await?;
-                Ok(TxView::TransactionView(tx.transaction_with_status))
+                Ok(TxView::TransactionView(tx.into()))
             }
             StructureType::DoubleEntry => self
                 .inner_get_transaction_info(ctx.clone(), tx_hash)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Add timestamp for rpc query_transactions with native structure_type.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

Breaking Change: 

```rust
async fn query_transactions(
    &self,
    payload: QueryTransactionsPayload,
) -> RpcResult<PaginationResponse<TxView>>;

pub enum TxView {
    TransactionView(TransactionWithRichStatus), // modify: replace TransactionWithStatus
    TransactionInfo(TransactionInfo),
}

// new
pub struct TransactionWithRichStatus {
    pub transaction: Option<TransactionView>,
    pub tx_status: TxRichStatus,
}

// new
pub struct TxRichStatus {
    pub status: Status,
    pub block_hash: Option<H256>,
    pub reason: Option<String>,
    pub timestamp: Option<u64>,
}
```

**Special notes for your reviewer**:

