### PR TITLE
fix(storage): get tx_hash when query transaction by script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arc-swap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "arrayvec"
@@ -755,7 +755,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 name = "core-rpc"
 version = "0.2.0-beta.3"
 dependencies = [
- "arc-swap 1.4.0",
+ "arc-swap 1.5.0",
  "async-trait",
  "bincode",
  "ckb-dao-utils",
@@ -817,7 +817,7 @@ dependencies = [
 name = "core-storage"
 version = "0.2.0-beta.3"
 dependencies = [
- "arc-swap 1.4.0",
+ "arc-swap 1.5.0",
  "bson",
  "ckb-jsonrpc-types",
  "ckb-types",
@@ -1934,9 +1934,9 @@ checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -3882,9 +3882,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "52963f91310c08d91cb7bff5786dfc8b79642ab839e188187e92105dbfb9d2c8"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -3963,7 +3963,7 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 name = "tracing"
 version = "0.1.0"
 dependencies = [
- "arc-swap 1.4.0",
+ "arc-swap 1.5.0",
  "lazy_static",
  "minitrace",
  "minitrace-jaeger",
@@ -4342,7 +4342,7 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 name = "xsql"
 version = "0.1.0"
 dependencies = [
- "arc-swap 1.4.0",
+ "arc-swap 1.5.0",
  "base64",
  "bson",
  "ckb-jsonrpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,10 +266,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bson"
-version = "2.0.1"
+name = "bson2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58d466782b57e0001c8e97c6a70c01c2359d7e13e257a83654c0b783ecc139"
+checksum = "5ce5e25a87f623d60edefc5493ee5628e3111460901ab5a96d2507550f6fe0fc"
 dependencies = [
  "ahash",
  "base64",
@@ -818,7 +818,7 @@ name = "core-storage"
 version = "0.2.0-beta.3"
 dependencies = [
  "arc-swap 1.5.0",
- "bson",
+ "bson2",
  "ckb-jsonrpc-types",
  "ckb-types",
  "clap",
@@ -846,7 +846,7 @@ dependencies = [
 name = "core-synchronization"
 version = "0.2.0-beta.3"
 dependencies = [
- "bson",
+ "bson2",
  "ckb-jsonrpc-types",
  "ckb-types",
  "common",
@@ -2906,12 +2906,12 @@ dependencies = [
 
 [[package]]
 name = "rbatis"
-version = "3.0.13"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f9eff390a4082270a5ee126e97e99de7321666f37c83f6b1c0c48858fafb5d"
+checksum = "4bf02ea36eae53f6ac86f7369e81fb28e9e48434cf8680f6cf58355f59d6c86f"
 dependencies = [
  "async-trait",
- "bson",
+ "bson2",
  "chrono",
  "futures",
  "futures-core",
@@ -2930,14 +2930,14 @@ dependencies = [
 
 [[package]]
 name = "rbatis-core"
-version = "3.0.9"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd4b6e9bba0a55b6dc4df4fc9b2ef234aa57896be5b54320c959534c5e324fe"
+checksum = "d3e5f424cece72d33e0b665d12e0435de39ec4f9846bc375974f819a4aa837c2"
 dependencies = [
  "base64",
  "bigdecimal",
  "bit-vec 0.6.3",
- "bson",
+ "bson2",
  "chrono",
  "hex",
  "ipnetwork",
@@ -2954,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "rbatis-macro-driver"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7814fa9a53e844b938f90cb12e4edd1c976304ca47ded8cd075c42a89a1f518"
+checksum = "a11a695ca04833906036262efa27ef4b7afa9718892e968a91db99696cdae719"
 dependencies = [
  "html_parser",
  "proc-macro2",
@@ -2966,13 +2966,13 @@ dependencies = [
 
 [[package]]
 name = "rbatis_sql"
-version = "3.0.3"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566102bdb8cd80e2d8168fcd7308f3662fa7519aec88f45ac6bf823bc8427c90"
+checksum = "df98993efdb2919fc14ac0d0fb25d9a39df02ac722e35532a2517fec0375c625"
 dependencies = [
  "async-trait",
  "base64",
- "bson",
+ "bson2",
  "dashmap",
  "rbatis_sql_macro",
  "serde",
@@ -2980,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "rbatis_sql_macro"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4e5829edbbf3236385ec8f91dff2e9d619b52092a74fcf290a757da2e1785c"
+checksum = "585efd8815ccb5a23b2611a195af074a36f9ad29e1d0c5c3b7c4f259d58fe1ba"
 dependencies = [
  "async-trait",
  "base64",
@@ -3882,9 +3882,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52963f91310c08d91cb7bff5786dfc8b79642ab839e188187e92105dbfb9d2c8"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -3899,9 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4344,7 +4344,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap 1.5.0",
  "base64",
- "bson",
+ "bson2",
  "ckb-jsonrpc-types",
  "ckb-types",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,9 +1623,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2474,9 +2474,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.70"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg 1.0.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 core-cli = { path = "core/cli" }
 log = "0.4"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "cargo_bench_support"] }

--- a/apm/tracing/Cargo.toml
+++ b/apm/tracing/Cargo.toml
@@ -12,4 +12,4 @@ lazy_static = "1.4"
 minitrace = { git = "https://github.com/tikv/minitrace-rust.git" }
 minitrace-jaeger = { git = "https://github.com/tikv/minitrace-rust.git" }
 minitrace-macro = { git = "https://github.com/tikv/minitrace-rust.git" }
-tokio = { version = "1.13", features = ["rt", "sync"] }
+tokio = { version = "1.14", features = ["rt", "sync"] }

--- a/apm/tracing/Cargo.toml
+++ b/apm/tracing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = "1.4"
+arc-swap = "1.5"
 lazy_static = "1.4"
 minitrace = { git = "https://github.com/tikv/minitrace-rust.git" }
 minitrace-jaeger = { git = "https://github.com/tikv/minitrace-rust.git" }

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 log4rs = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.13", features = ["time"] }
+tokio = { version = "1.14", features = ["time"] }
 toml = "0.5"
 
 common = { path = "../../common" }

--- a/core/inspection/Cargo.toml
+++ b/core/inspection/Cargo.toml
@@ -10,7 +10,7 @@ ckb-jsonrpc-types = "0.101"
 ckb-types = "0.101"
 hex = "0.4"
 log = "0.4"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread", "sync"] }
 
 common = { path = "../../common" }
 core-storage = { path = "../storage" }

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = "1.4"
+arc-swap = "1.5"
 async-trait = "0.1"
 bincode = "1.3"
 clap = "2.33"

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.11"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread", "sync"] }
 
 jsonrpsee-http-server = "0.4"
 jsonrpsee-proc-macros = "0.4"

--- a/core/rpc/src/tests/rpc_test.rs
+++ b/core/rpc/src/tests/rpc_test.rs
@@ -1,8 +1,45 @@
 use super::*;
+use tokio::test;
 
 #[ignore]
 #[tokio::test]
 async fn test() {
     let engine = RpcTestEngine::new_pg(NetworkType::Mainnet, "127.0.0.1").await;
     let _rpc = engine.rpc(NetworkType::Mainnet);
+}
+
+#[test]
+async fn test_1() {
+    init_debugger();
+
+    let engine = RpcTestEngine::new_pg(NetworkType::Testnet, "47.242.31.83").await;
+    let rpc = engine.rpc(NetworkType::Testnet);
+
+    let mut asset_info = HashSet::new();
+    asset_info.insert(crate::types::AssetInfo {
+        asset_type: crate::types::AssetType::UDT,
+        udt_hash: H256::from_str(
+            "f21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd",
+        )
+        .unwrap(),
+    });
+
+    let payload = QueryTransactionsPayload {
+        item: crate::types::JsonItem::Identity(String::from(
+            "0x001a4ff63598e43af9cd42324abb7657fa849c5bc3",
+        )),
+        asset_infos: asset_info,
+        structure_type: StructureType::Native,
+        extra: None,
+        block_range: None,
+        pagination: common::PaginationRequest {
+            cursor: Some(Bytes::from(vec![127, 255, 255, 255, 255, 255, 255, 255])),
+            order: common::Order::Desc,
+            limit: Some(1),
+            skip: Some(0),
+            return_count: false,
+        },
+    };
+
+    rpc.query_transactions(payload).await.unwrap();
 }

--- a/core/rpc/src/tests/rpc_test.rs
+++ b/core/rpc/src/tests/rpc_test.rs
@@ -1,45 +1,8 @@
 use super::*;
-use tokio::test;
 
 #[ignore]
 #[tokio::test]
 async fn test() {
     let engine = RpcTestEngine::new_pg(NetworkType::Mainnet, "127.0.0.1").await;
     let _rpc = engine.rpc(NetworkType::Mainnet);
-}
-
-#[test]
-async fn test_1() {
-    init_debugger();
-
-    let engine = RpcTestEngine::new_pg(NetworkType::Testnet, "47.242.31.83").await;
-    let rpc = engine.rpc(NetworkType::Testnet);
-
-    let mut asset_info = HashSet::new();
-    asset_info.insert(crate::types::AssetInfo {
-        asset_type: crate::types::AssetType::UDT,
-        udt_hash: H256::from_str(
-            "f21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd",
-        )
-        .unwrap(),
-    });
-
-    let payload = QueryTransactionsPayload {
-        item: crate::types::JsonItem::Identity(String::from(
-            "0x001a4ff63598e43af9cd42324abb7657fa849c5bc3",
-        )),
-        asset_infos: asset_info,
-        structure_type: StructureType::Native,
-        extra: None,
-        block_range: None,
-        pagination: common::PaginationRequest {
-            cursor: Some(Bytes::from(vec![127, 255, 255, 255, 255, 255, 255, 255])),
-            order: common::Order::Desc,
-            limit: Some(1),
-            skip: Some(0),
-            return_count: false,
-        },
-    };
-
-    rpc.query_transactions(payload).await.unwrap();
 }

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -15,7 +15,7 @@ jsonrpsee-proc-macros = "0.4"
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread", "time"] }
 
 common = { path = "../../common" }
 core-extensions = { path = "../extensions" }

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bson = "2.0"
+bson2 = "2.0"
 # ckb-indexer = { git = "https://github.com/KaoImin/ckb-indexer", branch = "mercury" }
 ckb-types = "0.101"
 ckb-jsonrpc-types = "0.101"
@@ -19,7 +19,7 @@ log = "0.4"
 rbatis = { version = "3.0", default-features = false,  features = ["all-database", "runtime-tokio-native-tls", "upper_case_sql_keyword"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 common = { path = "../../common" }

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -29,7 +29,7 @@ db_rocksdb = { path = "../../db/rocksdb", package = "rocksdb" }
 db_xsql = { path = "../../db/xsql", package = "xsql" }
 
 [dev-dependencies]
-arc-swap = "1.4"
+arc-swap = "1.5"
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 env_logger = "0.9"
 rand = "0.7"

--- a/core/storage/src/relational/mod.rs
+++ b/core/storage/src/relational/mod.rs
@@ -319,12 +319,10 @@ impl Storage for RelationalStorage {
             }
 
             i_cell.last().unwrap().id
+        } else if pagination.order.is_asc() {
+            i64::MIN
         } else {
-            if pagination.order.is_asc() {
-                i64::MIN
-            } else {
-                i64::MAX
-            }
+            i64::MAX
         };
 
         let lock_hashes = lock_hashes
@@ -362,26 +360,12 @@ impl Storage for RelationalStorage {
                 )
                 .await?
             }
+        } else if pagination.order.is_asc() {
+            sql::fetch_distinct_tx_hash_asc(&mut conn, &cursor, &lock_hashes, &type_hashes, &limit)
+                .await?
         } else {
-            if pagination.order.is_asc() {
-                sql::fetch_distinct_tx_hash_asc(
-                    &mut conn,
-                    &cursor,
-                    &lock_hashes,
-                    &type_hashes,
-                    &limit,
-                )
+            sql::fetch_distinct_tx_hash_desc(&mut conn, &cursor, &lock_hashes, &type_hashes, &limit)
                 .await?
-            } else {
-                sql::fetch_distinct_tx_hash_desc(
-                    &mut conn,
-                    &cursor,
-                    &lock_hashes,
-                    &type_hashes,
-                    &limit,
-                )
-                .await?
-            }
         };
 
         let tx_tables = self

--- a/core/storage/src/relational/mod.rs
+++ b/core/storage/src/relational/mod.rs
@@ -302,42 +302,95 @@ impl Storage for RelationalStorage {
             .into());
         }
 
-        let pag = {
-            let cursor = if let Some(cur) = pagination.cursor.clone() {
-                let mut conn = self.pool.acquire().await?;
-                let id = i64::from_be_bytes(to_fixed_array(&cur[0..8]));
-                let w = self.pool.wrapper().eq("id", id);
-                let tx = conn.fetch_by_wrapper::<TransactionTable>(w).await?;
-                let w = self.pool.wrapper().eq("tx_hash", tx.tx_hash);
-                let mut i_cell = conn.fetch_list_by_wrapper::<IndexerCellTable>(w).await?;
-                i_cell.sort();
-                Some(Bytes::from(
-                    i_cell.last().unwrap().id.to_be_bytes().to_vec(),
-                ))
+        let cursor = if let Some(cur) = pagination.cursor.clone() {
+            let mut conn = self.pool.acquire().await?;
+            let id = i64::from_be_bytes(to_fixed_array(&cur[0..8]));
+            let w = if pagination.order.is_asc() {
+                self.pool.wrapper().ge("id", id).limit(1)
             } else {
-                None
+                self.pool.wrapper().le("id", id).limit(1)
             };
+            let tx = conn.fetch_by_wrapper::<TransactionTable>(w).await?;
+            let w = self.pool.wrapper().eq("tx_hash", tx.tx_hash);
+            let mut i_cell = conn.fetch_list_by_wrapper::<IndexerCellTable>(w).await?;
+            i_cell.sort();
+            if !pagination.order.is_asc() {
+                i_cell.reverse();
+            }
 
-            PaginationRequest {
-                cursor,
-                order: pagination.order.clone(),
-                limit: pagination.limit,
-                skip: pagination.skip,
-                return_count: pagination.return_count,
+            i_cell.last().unwrap().id
+        } else {
+            if pagination.order.is_asc() {
+                i64::MIN
+            } else {
+                i64::MAX
             }
         };
 
-        let cells = self
-            .query_indexer_cells(lock_hashes, type_hashes, block_range.clone(), pag)
-            .await?;
-        let tx_hashes = cells
-            .response
-            .iter()
-            .map(|i_cell| i_cell.tx_hash.clone())
+        let lock_hashes = lock_hashes
+            .into_iter()
+            .map(|hash| to_rb_bytes(&hash.0))
+            .collect::<Vec<_>>();
+        let type_hashes = type_hashes
+            .into_iter()
+            .map(|hash| to_rb_bytes(&hash.0))
             .collect::<Vec<_>>();
 
+        let mut conn = self.pool.acquire().await?;
+        let limit = pagination.limit.unwrap_or(u64::MAX);
+        let tx_hashes = if let Some(range) = block_range.clone() {
+            if pagination.order.is_asc() {
+                sql::fetch_distinct_tx_hash_with_range_asc(
+                    &mut conn,
+                    &cursor,
+                    &range.min(),
+                    &range.max(),
+                    &lock_hashes,
+                    &type_hashes,
+                    &limit,
+                )
+                .await?
+            } else {
+                sql::fetch_distinct_tx_hash_with_range_desc(
+                    &mut conn,
+                    &cursor,
+                    &range.min(),
+                    &range.max(),
+                    &lock_hashes,
+                    &type_hashes,
+                    &limit,
+                )
+                .await?
+            }
+        } else {
+            if pagination.order.is_asc() {
+                sql::fetch_distinct_tx_hash_asc(
+                    &mut conn,
+                    &cursor,
+                    &lock_hashes,
+                    &type_hashes,
+                    &limit,
+                )
+                .await?
+            } else {
+                sql::fetch_distinct_tx_hash_desc(
+                    &mut conn,
+                    &cursor,
+                    &lock_hashes,
+                    &type_hashes,
+                    &limit,
+                )
+                .await?
+            }
+        };
+
         let tx_tables = self
-            .query_transactions(ctx.clone(), tx_hashes, block_range, pagination)
+            .query_transactions(
+                ctx.clone(),
+                tx_hashes.into_iter().map(|i| i.tx_hash).collect(),
+                block_range,
+                pagination,
+            )
             .await?;
         let txs_wrapper = self
             .get_transactions_with_status(ctx, tx_tables.response)

--- a/core/storage/src/relational/remove.rs
+++ b/core/storage/src/relational/remove.rs
@@ -1,5 +1,5 @@
 use crate::relational::table::{
-    BlockTable, CanonicalChainTable, IndexerCellTable, LiveCellTable, SyncStatus, TransactionTable,
+    BlockTable, CanonicalChainTable, CellTable, IndexerCellTable, LiveCellTable, SyncStatus, TransactionTable,
 };
 use crate::relational::{empty_rb_bytes, sql, to_rb_bytes, RelationalStorage};
 
@@ -26,6 +26,8 @@ impl RelationalStorage {
             .collect::<Vec<_>>();
 
         tx.remove_by_column::<TransactionTable, RbBytes>("block_hash", &block_hash)
+            .await?;
+        tx.remove_batch_by_column::<CellTable, RbBytes>("tx_hash", &tx_hashes)
             .await?;
         tx.remove_batch_by_column::<LiveCellTable, RbBytes>("tx_hash", &tx_hashes)
             .await?;

--- a/core/storage/src/relational/remove.rs
+++ b/core/storage/src/relational/remove.rs
@@ -1,4 +1,6 @@
-use crate::relational::table::{BlockTable, CanonicalChainTable, LiveCellTable, TransactionTable};
+use crate::relational::table::{
+    BlockTable, CanonicalChainTable, IndexerCellTable, LiveCellTable, SyncStatus, TransactionTable,
+};
 use crate::relational::{empty_rb_bytes, sql, to_rb_bytes, RelationalStorage};
 
 use common::{Context, Result};
@@ -27,6 +29,8 @@ impl RelationalStorage {
             .await?;
         tx.remove_batch_by_column::<LiveCellTable, RbBytes>("tx_hash", &tx_hashes)
             .await?;
+        tx.remove_batch_by_column::<IndexerCellTable, RbBytes>("tx_hash", &tx_hashes)
+            .await?;
 
         for tx_hash in tx_hashes.iter() {
             sql::rollback_consume_cell(tx, &empty_rb_bytes(), tx_hash).await?;
@@ -39,13 +43,15 @@ impl RelationalStorage {
     pub(crate) async fn remove_block_table(
         &self,
         _ctx: Context,
-        _block_number: BlockNumber,
+        block_number: BlockNumber,
         block_hash: RbBytes,
         tx: &mut RBatisTxExecutor<'_>,
     ) -> Result<()> {
         tx.remove_by_column::<BlockTable, RbBytes>("block_hash", &block_hash)
             .await?;
         tx.remove_by_column::<CanonicalChainTable, RbBytes>("block_hash", &block_hash)
+            .await?;
+        tx.remove_by_column::<SyncStatus, u64>("block_number", &block_number)
             .await?;
         Ok(())
     }

--- a/core/storage/src/relational/remove.rs
+++ b/core/storage/src/relational/remove.rs
@@ -1,5 +1,6 @@
 use crate::relational::table::{
-    BlockTable, CanonicalChainTable, CellTable, IndexerCellTable, LiveCellTable, SyncStatus, TransactionTable,
+    BlockTable, CanonicalChainTable, CellTable, IndexerCellTable, LiveCellTable, SyncStatus,
+    TransactionTable,
 };
 use crate::relational::{empty_rb_bytes, sql, to_rb_bytes, RelationalStorage};
 

--- a/core/storage/src/relational/sql.rs
+++ b/core/storage/src/relational/sql.rs
@@ -1,7 +1,7 @@
 use crate::relational::table::{MercuryId, ScriptTable, TxHash};
 
 use db_xsql::rbatis::executor::{RBatisConnExecutor, RBatisTxExecutor};
-use db_xsql::rbatis::{py_sql, sql, Bytes as RbBytes};
+use db_xsql::rbatis::{sql, Bytes as RbBytes};
 
 #[sql(
     tx,

--- a/core/storage/src/relational/sql.rs
+++ b/core/storage/src/relational/sql.rs
@@ -1,7 +1,7 @@
 use crate::relational::table::{MercuryId, ScriptTable, TxHash};
 
 use db_xsql::rbatis::executor::{RBatisConnExecutor, RBatisTxExecutor};
-use db_xsql::rbatis::{sql, Bytes as RbBytes};
+use db_xsql::rbatis::{py_sql, sql, Bytes as RbBytes};
 
 #[sql(
     tx,
@@ -85,6 +85,66 @@ pub async fn query_scripts_by_partial_arg(
     from: &u32,
     len: &u32,
 ) -> Vec<ScriptTable> {
+}
+
+#[sql(
+    conn,
+    "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
+    WHERE id > $1 AND lock_hash in $2 AND type_hash in $3 ORDER BY id ASC limit $4"
+)]
+pub async fn fetch_distinct_tx_hash_asc(
+    conn: &mut RBatisConnExecutor<'_>,
+    cursor: &i64,
+    lock_hashes: &[RbBytes],
+    type_hashes: &[RbBytes],
+    limit: &u64,
+) -> Vec<TxHash> {
+}
+
+#[sql(
+    conn,
+    "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
+    WHERE id < $1 AND lock_hash in $2 AND type_hash in $3 ORDER BY id DESC limit $4"
+)]
+pub async fn fetch_distinct_tx_hash_desc(
+    conn: &mut RBatisConnExecutor<'_>,
+    current: &i64,
+    lock_hashes: &[RbBytes],
+    type_hashes: &[RbBytes],
+    limit: &u64,
+) -> Vec<TxHash> {
+}
+
+#[sql(
+    conn,
+    "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
+    WHERE id > $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in $4 AND type_hash in $5 ORDER BY id ASC limit $6"
+)]
+pub async fn fetch_distinct_tx_hash_with_range_asc(
+    conn: &mut RBatisConnExecutor<'_>,
+    cursor: &i64,
+    from: &u64,
+    to: &u64,
+    lock_hashes: &[RbBytes],
+    type_hashes: &[RbBytes],
+    limit: &u64,
+) -> Vec<TxHash> {
+}
+
+#[sql(
+    conn,
+    "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
+    WHERE id < $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in $4 AND type_hash in $5 ORDER BY id DESC limit $6"
+)]
+pub async fn fetch_distinct_tx_hash_with_range_desc(
+    conn: &mut RBatisConnExecutor<'_>,
+    cursor: &i64,
+    from: &u64,
+    to: &u64,
+    lock_hashes: &[RbBytes],
+    type_hashes: &[RbBytes],
+    limit: &u64,
+) -> Vec<TxHash> {
 }
 
 #[sql(

--- a/core/storage/src/relational/sql.rs
+++ b/core/storage/src/relational/sql.rs
@@ -90,7 +90,7 @@ pub async fn query_scripts_by_partial_arg(
 #[sql(
     conn,
     "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
-    WHERE id > $1 AND lock_hash in $2 AND type_hash in $3 ORDER BY id ASC limit $4"
+    WHERE id > $1 AND lock_hash in ($2) AND type_hash in ($3) ORDER BY id ASC limit $4"
 )]
 pub async fn fetch_distinct_tx_hash_asc(
     conn: &mut RBatisConnExecutor<'_>,
@@ -104,7 +104,7 @@ pub async fn fetch_distinct_tx_hash_asc(
 #[sql(
     conn,
     "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
-    WHERE id < $1 AND lock_hash in $2 AND type_hash in $3 ORDER BY id DESC limit $4"
+    WHERE id < $1 AND lock_hash in ($2) AND type_hash in ($3) ORDER BY id DESC limit $4"
 )]
 pub async fn fetch_distinct_tx_hash_desc(
     conn: &mut RBatisConnExecutor<'_>,
@@ -118,7 +118,7 @@ pub async fn fetch_distinct_tx_hash_desc(
 #[sql(
     conn,
     "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
-    WHERE id > $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in $4 AND type_hash in $5 ORDER BY id ASC limit $6"
+    WHERE id > $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in ($4) AND type_hash in ($5) ORDER BY id ASC limit $6"
 )]
 pub async fn fetch_distinct_tx_hash_with_range_asc(
     conn: &mut RBatisConnExecutor<'_>,
@@ -134,7 +134,7 @@ pub async fn fetch_distinct_tx_hash_with_range_asc(
 #[sql(
     conn,
     "SELECT DISTINCT tx_hash FROM mercury_indexer_cell 
-    WHERE id < $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in $4 AND type_hash in $5 ORDER BY id DESC limit $6"
+    WHERE id < $1 AND block_number >= $2 AND block_number <= $3 AND lock_hash in ($4) AND type_hash in ($5) ORDER BY id DESC limit $6"
 )]
 pub async fn fetch_distinct_tx_hash_with_range_desc(
     conn: &mut RBatisConnExecutor<'_>,

--- a/core/synchronization/Cargo.toml
+++ b/core/synchronization/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bson = "2.0"
+bson2 = "2.0"
 ckb-jsonrpc-types = "0.101"
 ckb-types = "0.101"
 futures = "0.3"
@@ -19,7 +19,7 @@ rlp = "0.5"
 parking_lot = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 common = { path = "../../common" }
 core-storage = { path = "../storage" }

--- a/db/xsql/Cargo.toml
+++ b/db/xsql/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13"
-bson = "2.0"
+bson2 = "2.0"
 ckb-jsonrpc-types = "0.101"
 ckb-types = "0.101"
 is_sorted = "0.1"

--- a/db/xsql/Cargo.toml
+++ b/db/xsql/Cargo.toml
@@ -21,7 +21,7 @@ common = { path = "../../common" }
 db_protocol = { path = "../protocol", package = "protocol" }
 
 [dev-dependencies]
-arc-swap = "1.4"
+arc-swap = "1.5"
 criterion = { version = "0.3", features = ["async_tokio"] }
 env_logger = "0.9"
 rand = "0.7"

--- a/db/xsql/src/page.rs
+++ b/db/xsql/src/page.rs
@@ -1,6 +1,6 @@
 use common::{Order, PaginationRequest};
 
-use bson::Bson;
+use bson2::Bson;
 use rbatis::plugin::page::{IPageRequest, PagePlugin};
 use rbatis::{core::Error as RbError, sql::TEMPLATE, DriverType};
 use serde::{Deserialize, Serialize};

--- a/devtools/create_table/create_table.sql
+++ b/devtools/create_table/create_table.sql
@@ -164,12 +164,13 @@ CREATE INDEX "index_cell_table_consumed_block_number" ON "public"."mercury_cell"
 );
 
 CREATE INDEX "index_transaction_table_tx_hash" ON "mercury_transaction" USING btree ("tx_hash" "pg_catalog"."bytea_ops" ASC NULLS LAST);
-CREATE INDEX "index_transaction_table_block_hash" ON "mercury_transaction" USING btree (
-  "block_hash"
-);
+CREATE INDEX "index_transaction_table_block_hash" ON "mercury_transaction" USING btree ("block_hash");
 
 CREATE INDEX "index_indexer_cell_table_lock_hash" ON "public"."mercury_indexer_cell" ("lock_hash");
 CREATE INDEX "index_indexer_cell_table_type_hash" ON "public"."mercury_indexer_cell" ("type_hash");
+CREATE INDEX "index_indexer_cell_table_tx_hash" ON "mercury_indexer_cell" USING btree (
+    "tx_hash" "pg_catalog"."bytea_ops" ASC NULLS LAST
+);
 CREATE INDEX "index_indexer_cell_table_id" ON "public"."mercury_indexer_cell" USING btree (
   "id" "pg_catalog"."int8_ops" ASC NULLS LAST
 );


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
1. Fix get tx_hash process when query transaction by script. Use the distinct keyword.
2. Build index on mercury_indexer_cell table tx_hash column.
3. Bump tokio version to 1.14
4. Change bson to bson2 which supports u64.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

