### PR TITLE
feat: support recycling all ACP cells

### DIFF
--- a/core/rpc/core/src/error.rs
+++ b/core/rpc/core/src/error.rs
@@ -98,6 +98,9 @@ pub enum CoreError {
     #[display(fmt = "Invalid adjust account number")]
     InvalidAdjustAccountNumber,
 
+    #[display(fmt = "Input UDT amount should be 0")]
+    NotZeroInputUDTAmount,
+
     #[display(fmt = "Invalid outpoint")]
     InvalidOutPoint,
 
@@ -172,6 +175,7 @@ impl RpcError for CoreError {
 
             CoreError::AdjustAccountOnCkb => -10040,
             CoreError::InvalidAdjustAccountNumber => -10041,
+            CoreError::NotZeroInputUDTAmount => -10042,
 
             CoreError::NeedAtLeastOneFromAndOneTo => -10050,
             CoreError::RequiredCKBLessThanMin => -10051,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Let `Mercury` supports recycling all ACP cells, which means adjust accounts number to 0. This operation requires **NO** UDT assets was holded by the address.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

