### PR TITLE
fix(rpc): get_balance return error when pass record

### DIFF
--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -476,7 +476,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         let cells = if let Some(tip) = tip_block_number {
             let res = self
                 .storage
-                .get_historical_live_cells(ctx, lock_hashes, type_hashes, tip)
+                .get_historical_live_cells(ctx, lock_hashes, type_hashes, tip, out_point)
                 .await
                 .map_err(|e| CoreError::DBError(e.to_string()))?;
 

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -441,10 +441,11 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                                 .into());
                             }
                         };
-                        let cell_address =
-                            self.script_to_address(&cell.cell_output.lock()).to_string();
-                        if record_address == cell_address {
-                            cells.push(cell);
+                        if let Ok(record_address) = Address::from_str(&record_address) {
+                            let record_lock: packed::Script = record_address.payload().into();
+                            if record_lock == cell.cell_output.lock() {
+                                cells.push(cell);
+                            }
                         }
                     } else {
                         // todo: support more locks

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -47,6 +47,7 @@ pub trait Storage {
         lock_hashes: Vec<H256>,
         type_hashes: Vec<H256>,
         tip_block_number: BlockNumber,
+        out_point: Option<packed::OutPoint>,
     ) -> Result<Vec<DetailedCell>>;
 
     /// Get cells from the database according to the given arguments.

--- a/core/storage/src/relational/fetch.rs
+++ b/core/storage/src/relational/fetch.rs
@@ -581,6 +581,7 @@ impl RelationalStorage {
         lock_hashes: Vec<RbBytes>,
         type_hashes: Vec<RbBytes>,
         tip_block_number: u64,
+        out_point: Option<packed::OutPoint>,
     ) -> Result<Vec<DetailedCell>> {
         let mut w = self
             .pool
@@ -596,6 +597,15 @@ impl RelationalStorage {
             .in_array("lock_hash", &lock_hashes);
         if !type_hashes.is_empty() {
             w = w.and().in_array("type_hash", &type_hashes);
+        }
+        if let Some(out_point) = out_point {
+            let tx_hash: H256 = out_point.tx_hash().unpack();
+            let output_index: u32 = out_point.index().unpack();
+            w = w
+                .and()
+                .eq("tx_hash", to_rb_bytes(&tx_hash.0))
+                .and()
+                .eq("output_index", output_index);
         }
 
         let mut conn = self.pool.acquire().await?;

--- a/core/storage/src/relational/fetch.rs
+++ b/core/storage/src/relational/fetch.rs
@@ -471,9 +471,35 @@ impl RelationalStorage {
         }
 
         if let Some(op) = out_point {
-            let res = self.query_live_cell_by_out_point(op).await?;
+            let cell = self.query_live_cell_by_out_point(op).await?;
+
+            let mut is_ok = true;
+            let lock_hash: H256 = cell.cell_output.lock().calc_script_hash().unpack();
+            let lock_hash = to_rb_bytes(&lock_hash.0);
+            if !lock_hashes.is_empty() {
+                is_ok = lock_hashes.contains(&lock_hash) && is_ok
+            };
+
+            if let Some(type_script) = cell.cell_output.type_().to_opt() {
+                let type_hash: H256 = type_script.calc_script_hash().unpack();
+                let type_hash = to_rb_bytes(&type_hash.0);
+                if !type_hashes.is_empty() {
+                    is_ok = type_hashes.contains(&type_hash) && is_ok
+                };
+            } else if !type_hashes.is_empty() {
+                is_ok = false
+            }
+
+            if let Some(range) = block_range {
+                is_ok = range.is_in(cell.block_number);
+            }
+
+            let mut response: Vec<DetailedCell> = vec![];
+            if is_ok {
+                response.push(cell);
+            }
             return Ok(PaginationResponse {
-                response: vec![res],
+                response,
                 next_cursor: None,
                 count: None,
             });

--- a/core/storage/src/relational/mod.rs
+++ b/core/storage/src/relational/mod.rs
@@ -143,6 +143,7 @@ impl Storage for RelationalStorage {
         lock_hashes: Vec<H256>,
         type_hashes: Vec<H256>,
         tip_block_number: BlockNumber,
+        out_point: Option<packed::OutPoint>,
     ) -> Result<Vec<DetailedCell>> {
         if lock_hashes.is_empty() {
             return Err(DBError::InvalidParameter(
@@ -161,7 +162,7 @@ impl Storage for RelationalStorage {
             .map(|hash| to_rb_bytes(&hash.0))
             .collect::<Vec<_>>();
 
-        self.query_historical_live_cells(ctx, lock_hashes, type_hashes, tip_block_number)
+        self.query_historical_live_cells(ctx, lock_hashes, type_hashes, tip_block_number, out_point)
             .await
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
- fix bug: get_balance return null when record id encoded based on short address
- fix bug: get_live_cells did not filter out point when tip_block_number specified
- fix bug: lack of filters in query_live_cells 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

