### PR TITLE
fix(rpc): fix get_balance statistics for acp and pw lock cell without type script

### DIFF
--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -770,10 +770,12 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         let mut occupied = occupied.as_u64();
         let lock_code_hash: H256 = cell.cell_output.lock().code_hash().unpack();
-        // To make CKB `free` represent available balance, pure ckb cell should be spendable.
+        // To make CKB `free` represent available balance, pure ckb cell, acp cell/pw lock cell without type script should be spendable.
         if cell.cell_data.is_empty()
             && cell.cell_output.type_().is_none()
-            && lock_code_hash == **SECP256K1_CODE_HASH.load()
+            && (lock_code_hash == **SECP256K1_CODE_HASH.load()
+                || lock_code_hash == **ACP_CODE_HASH.load()
+                || lock_code_hash == **PW_LOCK_CODE_HASH.load())
         {
             occupied = 0;
         }

--- a/tests/tests/rpc/get_balance.rs
+++ b/tests/tests/rpc/get_balance.rs
@@ -158,7 +158,7 @@ fn test_identity_ckb() {
         .unwrap();
     assert_eq!(acp_balance["ownership"]["type"], "Address");
     assert_eq!(acp_balance["asset_info"]["asset_type"], "CKB");
-    assert_eq!(acp_balance["free"], "1979699999470");
+    assert_eq!(acp_balance["free"], "1985799999470");
 
     let secp_balance = balances.iter().find(|balance|
         balance["ownership"]["value"] == "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9")
@@ -230,7 +230,7 @@ fn test_identity_all() {
         balance["asset_info"]["asset_type"] == "CKB"
         && balance["ownership"]["value"] == "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn")
         .unwrap();
-    assert_eq!(acp_ckb_balance["free"], "1979699999470");
+    assert_eq!(acp_ckb_balance["free"], "1985799999470");
 
     let secp_ckb_balance = balances.iter().find(|balance|
         balance["asset_info"]["asset_type"] == "CKB"
@@ -278,7 +278,7 @@ fn test_identity_multiple_assets() {
         balance["asset_info"]["asset_type"] == "CKB"
         && balance["ownership"]["value"] == "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn")
         .unwrap();
-    assert_eq!(acp_ckb_balance["free"], "1979699999470");
+    assert_eq!(acp_ckb_balance["free"], "1985799999470");
 
     let secp_ckb_balance = balances.iter().find(|balance|
         balance["asset_info"]["asset_type"] == "CKB"

--- a/tests/tests/rpc/query_transactions.rs
+++ b/tests/tests/rpc/query_transactions.rs
@@ -382,32 +382,32 @@ fn test_query_by_identity_udt() {
     );
     let r = &resp["result"];
     assert_eq!(r["next_cursor"], Value::Null);
-    assert_eq!(r["count"], 9);
+    assert_eq!(r["count"], 12);
     let txs = &r["response"].as_array().unwrap();
-    assert_eq!(txs.len(), 9);
+    assert_eq!(txs.len(), 12);
 
     assert_eq!(
-        txs[3]["value"]["tx_hash"],
+        txs[6]["value"]["tx_hash"],
         "0x3eb0a1974dd6a2b6c3ba220169cef6eec21e94d2267fab9a4e810accc693c8ed"
     );
     assert_eq!(
-        txs[4]["value"]["tx_hash"],
+        txs[7]["value"]["tx_hash"],
         "0x5b0b303647d191677e53b6d94bbeda36794ca6599705b4b4b7f693409bb915e3"
     );
     assert_eq!(
-        txs[5]["value"]["tx_hash"],
+        txs[8]["value"]["tx_hash"],
         "0xc095eefa53e137e6e7be70b1df836513e5b28a4578845f7aa26853d456a9887f"
     );
     assert_eq!(
-        txs[6]["value"]["tx_hash"],
+        txs[9]["value"]["tx_hash"],
         "0x0c9fe78130502bcd53656f6224072bd44b4ab357ba7351e1f37e72d4f12b07b9"
     );
     assert_eq!(
-        txs[7]["value"]["tx_hash"],
+        txs[10]["value"]["tx_hash"],
         "0x1256aa76ef4dd7805ad4b1cf9efe87211bd3cdb5dae0e440c29ce4a0db73ea41"
     );
     assert_eq!(
-        txs[8]["value"]["tx_hash"],
+        txs[11]["value"]["tx_hash"],
         "0x88e03bf37db9770a0e496a98bc17cdc31095392a169f0d416bad07b9c58b3501"
     );
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Fix get_balance statistics for acp and pw lock cell without type script, considering that for acp cell and pw lock cell without type script, full capacity can be provided when pooling money.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

