### PR TITLE
fix(sync): re-create table should re-create index too

### DIFF
--- a/core/synchronization/src/sql.rs
+++ b/core/synchronization/src/sql.rs
@@ -51,7 +51,8 @@ pub async fn drop_consume_info_table(tx: &mut RBatisTxExecutor<'_>) -> () {}
 
 #[sql(
     tx,
-    "CREATE TABLE mercury_live_cell(
+    "
+    CREATE TABLE mercury_live_cell(
     id bigint PRIMARY KEY,
     tx_hash bytea NOT NULL,
     output_index int NOT NULL,
@@ -71,20 +72,33 @@ pub async fn drop_consume_info_table(tx: &mut RBatisTxExecutor<'_>) -> () {}
     type_args bytea,
     type_script_type smallint,
     data bytea
-)"
+    );
+    CREATE INDEX \"index_live_cell_table_block_hash\" ON \"mercury_live_cell\" (\"block_hash\");
+    CREATE INDEX \"index_live_cell_table_block_number\" ON \"mercury_live_cell\" (\"block_number\"); 
+    CREATE INDEX \"index_live_cell_table_tx_hash_and_output_index\" ON \"mercury_live_cell\" (\"tx_hash\", \"output_index\");
+    CREATE INDEX \"index_live_cell_table_lock_hash\" ON \"mercury_live_cell\" (\"lock_hash\");
+    CREATE INDEX \"index_live_cell_table_lock_code_hash_and_lock_script_type\" ON \"mercury_live_cell\" (\"lock_code_hash\", \"lock_script_type\");
+    CREATE INDEX \"index_live_cell_table_type_code_hash_and_type_script_type\" ON \"mercury_live_cell\" (\"type_code_hash\", \"type_script_type\");
+    "
 )]
 pub async fn create_live_cell_table(tx: &mut RBatisTxExecutor<'_>) -> () {}
 
 #[sql(
     tx,
-    "CREATE TABLE mercury_script(
+    "
+    CREATE TABLE mercury_script(
         script_hash bytea NOT NULL PRIMARY KEY,
         script_hash_160 bytea NOT NULL,
         script_code_hash bytea NOT NULL,
         script_args bytea,
         script_type smallint NOT NULL,
         script_args_len int
-    );"
+    );
+    CREATE INDEX \"index_script_table_script_hash\" ON \"mercury_script\" (\"script_hash\");
+    CREATE INDEX \"index_script_table_code_hash\" ON \"mercury_script\" (\"script_code_hash\");
+    CREATE INDEX \"index_script_table_args\" ON \"mercury_script\" (\"script_args\");
+    CREATE INDEX \"index_script_table_script_hash_160\" ON \"mercury_script\" USING btree (\"script_hash_160\");
+    ",
 )]
 pub async fn create_script_table(tx: &mut RBatisTxExecutor<'_>) -> () {}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Re-create table should re-create index too. Otherwise, when Mercury is restarted and the parallel synchronization is performed again, the indexes of more than one tables will be lost, and the insertion will be too slow to keep up with the ckb node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

