### PR TITLE
feat(rpc): add new transfer mode PayWithAcp and new rpc get_account_info

### DIFF
--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -13,6 +13,7 @@
   - [Method `get_block_info`](#method-get_block_info)
   - [Method `get_transaction_info`](#method-get_transaction_info)
   - [Method `query_transactions`](#method-query_transactions)
+  - [Method `get_account_info`](#method-get_account_info)
   - [Method `build_adjust_account_transaction`](#method-build_adjust_account_transaction)
   - [Method `build_transfer_transaction`](#method-build_transfer_transaction)
   - [Method `build_simple_transfer_transaction`](#method-build_simple_transfer_transaction)
@@ -99,6 +100,8 @@ Mode is used to specify whether the sender or the recipient provides the CKBytes
 - HoldByFrom: The sender provides CKBytes for the output cell.
 
 - HoldByTo: The recipient provides CKBytes for the output cell.
+
+- PayWithAcp: The sender provides CKBytes for the output cell. Different from the HoldByFrom mode, when transferring UDT assets, the CKBytes provided by the sender belongs to the recipient.
 
 ### Balance Type
 
@@ -535,6 +538,74 @@ echo '{
     "count": 1
   },
   "id": 42
+}
+```
+
+### Method `get_account_info`
+
+- `get_account_info(item, asset_info)`
+  - `item`: [`JsonItem`](#type-jsonitem)
+  - `asset_info`: [`AssetInfo`](#type-assetinfo)
+- result
+  - `account_number`: `Uint32`
+  - `account_address`: `string`
+  - `account_type`: `"Acp"|"PwLock"`
+
+**Usage**
+
+To return the account information for the given item and asset information. The account number returned can be used to determine whether an item has at least one specific UDT asset account.
+
+**Params**
+
+- `item` - Specify the object for getting the account information.
+  - If `item` is an identity, the account information corresponding to the identity will be queried.
+  - If `item` is an address, the account information corresponding to the address will be queried
+  - If `item`  is the ID of an unspent record, the account information corresponding to the record will be queried.
+- `asset_infos` - Specify a set of asset types for the query.
+  
+**Returns**
+
+  - `account_number`: The number of accounts for a specific UDT asset.
+  - `account_address`: The address corresponding to the account.
+  - `account_type`: The type of account.
+
+**Examples**
+
+- Request
+
+```shell
+echo '{
+  "id": 42,
+  "jsonrpc": "2.0",
+  "method": "get_account_info",
+  "params": [
+    {
+      "item": {
+        "type": "Address",
+        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+      },
+      "asset_info": {
+        "asset_type": "UDT",
+        "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
+      }
+    }
+  ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev
+```
+
+- Response
+
+```json
+{
+    "jsonrpc": "2.0", 
+    "result": {
+        "account_number": 1, 
+        "account_address": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn", 
+        "account_type": "Acp"
+    }, 
+    "id": 42
 }
 ```
 
@@ -2202,7 +2273,7 @@ Fields
 Fields
 
 - `to_infos`(Type: `Array<`[`ToInfo`](#type-toinfo)`>`): Specify the recipient's address and transfer amount.
-- `mode`  (Type:`"HoldByFrom"|"HoldByTo"`): Specify the mode of the provided capacity.
+- `mode`  (Type:`"HoldByFrom"|"HoldByTo"|PayWithAcp`): Specify the mode of the provided capacity.
 
 ### Type `ToInfo`
 

--- a/core/rpc/core/src/error.rs
+++ b/core/rpc/core/src/error.rs
@@ -136,6 +136,9 @@ pub enum CoreError {
 
     #[display(fmt = "Required CKB is not enough: {}", _0)]
     CkbIsNotEnough(String),
+
+    #[display(fmt = "Unsupport transfer mode: {}", _0)]
+    UnsupportTransferMode(String),
 }
 
 impl RpcError for CoreError {
@@ -168,6 +171,7 @@ impl RpcError for CoreError {
             CoreError::CkbClientError(_) => -11028,
             CoreError::CkbIsNotEnough(_) => -11029,
             CoreError::UDTIsNotEnough(_) => -11030,
+            CoreError::UnsupportTransferMode(_) => -11031,
 
             CoreError::MissingConsumedInfo => -10020,
 

--- a/core/rpc/core/src/impl.rs
+++ b/core/rpc/core/src/impl.rs
@@ -8,10 +8,10 @@ pub(crate) mod utils_types;
 use core_ckb_client::CkbRpc;
 use core_rpc_types::{
     indexer, AdjustAccountPayload, BlockInfo, DaoClaimPayload, DaoDepositPayload,
-    DaoWithdrawPayload, GetBalancePayload, GetBalanceResponse, GetBlockInfoPayload,
-    GetSpentTransactionPayload, GetTransactionInfoResponse, MercuryInfo, QueryTransactionsPayload,
-    SimpleTransferPayload, SudtIssuePayload, SyncState, TransactionCompletionResponse,
-    TransferPayload, TxView,
+    DaoWithdrawPayload, GetAccountInfoPayload, GetAccountInfoResponse, GetBalancePayload,
+    GetBalanceResponse, GetBlockInfoPayload, GetSpentTransactionPayload,
+    GetTransactionInfoResponse, MercuryInfo, QueryTransactionsPayload, SimpleTransferPayload,
+    SudtIssuePayload, SyncState, TransactionCompletionResponse, TransferPayload, TxView,
 };
 
 use crate::r#impl::build_tx::calculate_tx_size;
@@ -87,6 +87,13 @@ impl<C: CkbRpc> MercuryRpcServer for MercuryRpcImpl<C> {
         payload: QueryTransactionsPayload,
     ) -> RpcResult<PaginationResponse<TxView>> {
         rpc_impl!(self, inner_query_transactions, payload)
+    }
+
+    async fn get_account_info(
+        &self,
+        payload: GetAccountInfoPayload,
+    ) -> RpcResult<GetAccountInfoResponse> {
+        rpc_impl!(self, inner_get_account_info, payload)
     }
 
     async fn build_adjust_account_transaction(

--- a/core/rpc/core/src/impl/adjust_account.rs
+++ b/core/rpc/core/src/impl/adjust_account.rs
@@ -5,8 +5,8 @@ use core_ckb_client::CkbRpc;
 use core_rpc_types::consts::{ckb, DEFAULT_FEE_RATE, STANDARD_SUDT_CAPACITY};
 use core_rpc_types::lazy::{ACP_CODE_HASH, PW_LOCK_CODE_HASH, SECP256K1_CODE_HASH};
 use core_rpc_types::{
-    AdjustAccountPayload, AssetType, HashAlgorithm, Item, JsonItem, SignAlgorithm, SignatureAction,
-    Source, TransactionCompletionResponse,
+    AdjustAccountPayload, AssetType, GetAccountInfoPayload, GetAccountInfoResponse, HashAlgorithm,
+    Item, JsonItem, SignAlgorithm, SignatureAction, Source, TransactionCompletionResponse,
 };
 
 use common::hash::blake2b_256_to_160;
@@ -279,6 +279,45 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         let tx_view = self.update_tx_view_change_cell_by_index(tx_view.into(), 0, 0, actual_fee)?;
         Ok((tx_view, signature_actions))
+    }
+
+    pub(crate) async fn inner_get_account_info(
+        &self,
+        ctx: Context,
+        payload: GetAccountInfoPayload,
+    ) -> InnerResult<GetAccountInfoResponse> {
+        let item: Item = payload.item.clone().try_into()?;
+        let acp_address = self.get_acp_address_by_item(item.clone())?;
+        let identity_item = Item::Identity(utils::address_to_identity(&acp_address.to_string())?);
+        let mut asset_set = HashSet::new();
+        asset_set.insert(payload.asset_info.clone());
+
+        let lock_filter = if acp_address.is_acp() {
+            Some((**ACP_CODE_HASH.load()).clone())
+        } else if acp_address.is_pw_lock() {
+            Some((**PW_LOCK_CODE_HASH.load()).clone())
+        } else {
+            return Err(CoreError::UnsupportAddress.into());
+        };
+
+        let live_acps = self
+            .get_live_cells_by_item(
+                ctx.clone(),
+                identity_item.clone(),
+                asset_set,
+                None,
+                None,
+                lock_filter,
+                None,
+                false,
+                &mut PaginationRequest::default(),
+            )
+            .await?;
+
+        Ok(GetAccountInfoResponse {
+            account_number: live_acps.len() as u32,
+            account_address: acp_address.to_string(),
+        })
     }
 }
 

--- a/core/rpc/core/src/impl/adjust_account.rs
+++ b/core/rpc/core/src/impl/adjust_account.rs
@@ -5,8 +5,9 @@ use core_ckb_client::CkbRpc;
 use core_rpc_types::consts::{ckb, DEFAULT_FEE_RATE, STANDARD_SUDT_CAPACITY};
 use core_rpc_types::lazy::{ACP_CODE_HASH, PW_LOCK_CODE_HASH, SECP256K1_CODE_HASH};
 use core_rpc_types::{
-    AdjustAccountPayload, AssetType, GetAccountInfoPayload, GetAccountInfoResponse, HashAlgorithm,
-    Item, JsonItem, SignAlgorithm, SignatureAction, Source, TransactionCompletionResponse,
+    AccountType, AdjustAccountPayload, AssetType, GetAccountInfoPayload, GetAccountInfoResponse,
+    HashAlgorithm, Item, JsonItem, SignAlgorithm, SignatureAction, Source,
+    TransactionCompletionResponse,
 };
 
 use common::hash::blake2b_256_to_160;
@@ -292,10 +293,13 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         let mut asset_set = HashSet::new();
         asset_set.insert(payload.asset_info.clone());
 
-        let lock_filter = if acp_address.is_acp() {
-            Some((**ACP_CODE_HASH.load()).clone())
+        let (lock_filter, account_type) = if acp_address.is_acp() {
+            (Some((**ACP_CODE_HASH.load()).clone()), AccountType::Acp)
         } else if acp_address.is_pw_lock() {
-            Some((**PW_LOCK_CODE_HASH.load()).clone())
+            (
+                Some((**PW_LOCK_CODE_HASH.load()).clone()),
+                AccountType::PwLock,
+            )
         } else {
             return Err(CoreError::UnsupportAddress.into());
         };
@@ -317,6 +321,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         Ok(GetAccountInfoResponse {
             account_number: live_acps.len() as u32,
             account_address: acp_address.to_string(),
+            account_type,
         })
     }
 }

--- a/core/rpc/core/src/impl/adjust_account.rs
+++ b/core/rpc/core/src/impl/adjust_account.rs
@@ -35,43 +35,35 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         let account_number = payload.account_number.unwrap_or(1) as usize;
         let fee_rate = payload.fee_rate.unwrap_or(DEFAULT_FEE_RATE);
-        let item: Item = payload.item.clone().try_into()?;
 
         let mut asset_set = HashSet::new();
         asset_set.insert(payload.asset_info.clone());
 
-        let lock_script = self.get_acp_lock_by_item(item.clone())?;
-        let address = self.script_to_address(&lock_script);
+        let item: Item = payload.item.clone().try_into()?;
+        let acp_address = self.get_acp_address_by_item(item.clone())?;
+        let identity_item = Item::Identity(utils::address_to_identity(&acp_address.to_string())?);
 
-        let live_acps = if address.is_acp() {
-            self.get_live_cells_by_item(
-                ctx.clone(),
-                item.clone(),
-                asset_set,
-                None,
-                None,
-                Some((**ACP_CODE_HASH.load()).clone()),
-                None,
-                false,
-                &mut PaginationRequest::default(),
-            )
-            .await?
-        } else if address.is_pw_lock() {
-            self.get_live_cells_by_item(
-                ctx.clone(),
-                item.clone(),
-                asset_set,
-                None,
-                None,
-                Some((**PW_LOCK_CODE_HASH.load()).clone()),
-                None,
-                false,
-                &mut PaginationRequest::default(),
-            )
-            .await?
+        let lock_filter = if acp_address.is_acp() {
+            Some((**ACP_CODE_HASH.load()).clone())
+        } else if acp_address.is_pw_lock() {
+            Some((**PW_LOCK_CODE_HASH.load()).clone())
         } else {
-            vec![]
+            return Err(CoreError::UnsupportAddress.into());
         };
+
+        let live_acps = self
+            .get_live_cells_by_item(
+                ctx.clone(),
+                identity_item.clone(),
+                asset_set,
+                None,
+                None,
+                lock_filter,
+                None,
+                false,
+                &mut PaginationRequest::default(),
+            )
+            .await?;
         let live_acps_len = live_acps.len();
 
         if live_acps_len == account_number {
@@ -96,7 +88,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             .await
             .map(Some)
         } else {
-            if address.is_pw_lock() && account_number.is_zero() {
+            if acp_address.is_pw_lock() && account_number.is_zero() {
                 // pw lock cells cannot be fully recycled
                 // because they cannot be unlocked and converted into secp cells under the same ownership
                 return Err(CoreError::InvalidAdjustAccountNumber.into());

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -650,6 +650,11 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
     }
 
+    pub(crate) fn get_acp_address_by_item(&self, item: Item) -> InnerResult<Address> {
+        self.get_acp_lock_by_item(item)
+            .map(|script| self.script_to_address(&script))
+    }
+
     pub(crate) fn get_default_lock_hash_by_item(&self, item: Item) -> InnerResult<H160> {
         self.get_default_lock_by_item(item).map(|script| {
             let lock_hash: H256 = script.calc_script_hash().unpack();

--- a/core/rpc/core/src/lib.rs
+++ b/core/rpc/core/src/lib.rs
@@ -11,10 +11,10 @@ use common::{PaginationResponse, Result};
 use core_rpc_types::error::MercuryRpcError;
 use core_rpc_types::{
     indexer, AdjustAccountPayload, BlockInfo, DaoClaimPayload, DaoDepositPayload,
-    DaoWithdrawPayload, GetBalancePayload, GetBalanceResponse, GetBlockInfoPayload,
-    GetSpentTransactionPayload, GetTransactionInfoResponse, MercuryInfo, QueryTransactionsPayload,
-    SimpleTransferPayload, SudtIssuePayload, SyncState, TransactionCompletionResponse,
-    TransferPayload, TxView,
+    DaoWithdrawPayload, GetAccountInfoPayload, GetAccountInfoResponse, GetBalancePayload,
+    GetBalanceResponse, GetBlockInfoPayload, GetSpentTransactionPayload,
+    GetTransactionInfoResponse, MercuryInfo, QueryTransactionsPayload, SimpleTransferPayload,
+    SudtIssuePayload, SyncState, TransactionCompletionResponse, TransferPayload, TxView,
 };
 use core_storage::DBInfo;
 
@@ -42,6 +42,12 @@ pub trait MercuryRpc {
         &self,
         payload: QueryTransactionsPayload,
     ) -> RpcResult<PaginationResponse<TxView>>;
+
+    #[method(name = "get_account_info")]
+    async fn get_account_info(
+        &self,
+        payload: GetAccountInfoPayload,
+    ) -> RpcResult<GetAccountInfoResponse>;
 
     #[method(name = "build_adjust_account_transaction")]
     async fn build_adjust_account_transaction(

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -463,6 +463,13 @@ pub struct GetAccountInfoPayload {
 pub struct GetAccountInfoResponse {
     pub account_number: u32,
     pub account_address: String,
+    pub account_type: AccountType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum AccountType {
+    Acp,
+    PwLock,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -454,6 +454,18 @@ pub struct QueryTransactionsPayload {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct GetAccountInfoPayload {
+    pub item: JsonItem,
+    pub asset_info: AssetInfo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct GetAccountInfoResponse {
+    pub account_number: u32,
+    pub account_address: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AdjustAccountPayload {
     pub item: JsonItem,
     pub from: HashSet<JsonItem>,

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -222,6 +222,7 @@ pub enum TransactionStatus {
 pub enum Mode {
     HoldByFrom,
     HoldByTo,
+    PayWithAcp,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]

--- a/tests/tests/rpc/build_adjust_account_transaction.rs
+++ b/tests/tests/rpc/build_adjust_account_transaction.rs
@@ -49,7 +49,7 @@ fn test_udt() {
                     "asset_type": "UDT",
                     "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
                 },
-                "account_number": null,
+                "account_number": 2,
                 "extra_ckb": null,
                 "fee_rate": null
             }
@@ -114,8 +114,9 @@ fn test_udt_account_number() {
 
     let inputs = &tx["inputs"].as_array().unwrap();
     let outputs = &tx["outputs"].as_array().unwrap();
+
     assert_eq!(inputs.len(), 1);
-    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs.len(), 1);
 
     check_amount(outputs.iter(), 1000000000000, None);
     // Need output a new acp

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -368,7 +368,7 @@ fn test_ckb_pay_with_acp() {
         ]
     }"#,
     );
-    assert_ne!(resp["error"], Value::Null);  // Unsupport transfer mode: PayWithAcp when transfer CKB
+    assert_ne!(resp["error"], Value::Null); // Unsupport transfer mode: PayWithAcp when transfer CKB
 }
 
 #[test]
@@ -422,7 +422,10 @@ fn test_udt_pay_with_acp() {
     assert_eq!(inputs.len(), 1);
     assert_eq!(outputs.len(), 2);
 
-    let receiver_output_index = outputs.iter().position(|output| output["lock"]["args"] == "0x9acea8d012364c3e38c9586deb99dc80c809d712").unwrap();
+    let receiver_output_index = outputs
+        .iter()
+        .position(|output| output["lock"]["args"] == "0x9acea8d012364c3e38c9586deb99dc80c809d712")
+        .unwrap();
     assert_eq!(
         tx["outputs_data"][receiver_output_index],
         "0x05000000000000000000000000000000"

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -326,6 +326,118 @@ fn test_ckb_hold_by_to() {
 }
 
 #[test]
+fn test_ckb_pay_with_acp() {
+    let resp = post_http_request(
+        r#"{
+        "id": 42,
+        "jsonrpc": "2.0",
+        "method": "build_transfer_transaction",
+        "params": [
+            {
+                "asset_info": {
+                    "asset_type": "CKB",
+                    "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "from": {
+                    "items": [
+                        {
+                            "type": "Address",
+                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                        }
+                    ],
+                    "source": "Free"
+                },
+                "to": {
+                    "to_infos": [
+                        {
+                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                            "amount": "9650000000"
+                        }
+                    ],
+                    "mode": "PayWithAcp"
+                },
+                "pay_fee": null,
+                "change": null,
+                "fee_rate": null,
+                "since": {
+                    "flag": "Absolute",
+                    "type_": "BlockNumber",
+                    "value": 6000000
+                }
+            }
+        ]
+    }"#,
+    );
+    assert_ne!(resp["error"], Value::Null);  // Unsupport transfer mode: PayWithAcp when transfer CKB
+}
+
+#[test]
+fn test_udt_pay_with_acp() {
+    let resp = post_http_request(
+        r#"{
+        "id": 42,
+        "jsonrpc": "2.0",
+        "method": "build_transfer_transaction",
+        "params": [
+            {
+                "asset_info": {
+                    "asset_type": "UDT",
+                    "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
+                },
+                "from": {
+                    "items": [
+                        {
+                            "type": "Address",
+                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                        }
+                    ],
+                    "source": "Free"
+                },
+                "to": {
+                    "to_infos": [
+                        {
+                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                            "amount": "5"
+                        }
+                    ],
+                    "mode": "PayWithAcp"
+                },
+                "pay_fee": null,
+                "change": null,
+                "fee_rate": null,
+                "since": {
+                    "flag": "Absolute",
+                    "type_": "BlockNumber",
+                    "value": 6000000
+                }
+            }
+        ]
+    }"#,
+    );
+    let r = &resp["result"];
+    let tx = &r["tx_view"];
+
+    let inputs = &tx["inputs"].as_array().unwrap();
+    let outputs = &tx["outputs"].as_array().unwrap();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(outputs.len(), 2);
+
+    let receiver_output_index = outputs.iter().position(|output| output["lock"]["args"] == "0x9acea8d012364c3e38c9586deb99dc80c809d712").unwrap();
+    assert_eq!(
+        tx["outputs_data"][receiver_output_index],
+        "0x05000000000000000000000000000000"
+    );
+    let sender_output_index = outputs
+        .iter()
+        .position(|output| output["lock"]["args"] == "0xfa22aa0aaf155a6c816634c61512046b08923111")
+        .unwrap();
+    assert_eq!(
+        tx["outputs_data"][sender_output_index],
+        "0x9b000000000000000000000000000000"
+    );
+}
+
+#[test]
 fn test_ckb_pay_fee() {
     let resp = post_http_request(
         r#"{

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -372,7 +372,7 @@ fn test_ckb_pay_with_acp() {
 }
 
 #[test]
-fn test_udt_pay_with_acp() {
+fn test_udt_pay_with_acp_to_secp_address() {
     let resp = post_http_request(
         r#"{
         "id": 42,
@@ -430,6 +430,12 @@ fn test_udt_pay_with_acp() {
         tx["outputs_data"][receiver_output_index],
         "0x05000000000000000000000000000000"
     );
+    let receiver_output = outputs
+        .iter()
+        .find(|output| output["lock"]["args"] == "0x9acea8d012364c3e38c9586deb99dc80c809d712")
+        .unwrap();
+    assert_eq!(receiver_output["capacity"], "0x34e62ce00");
+
     let sender_output_index = outputs
         .iter()
         .position(|output| output["lock"]["args"] == "0xfa22aa0aaf155a6c816634c61512046b08923111")
@@ -438,7 +444,146 @@ fn test_udt_pay_with_acp() {
         tx["outputs_data"][sender_output_index],
         "0x9b000000000000000000000000000000"
     );
+    let sender_output = outputs
+        .iter()
+        .find(|output| output["lock"]["args"] == "0xfa22aa0aaf155a6c816634c61512046b08923111")
+        .unwrap();
+    assert_eq!(sender_output["capacity"], "0xea2e5a052f");
+
+    let witnesses = &tx["witnesses"].as_array().unwrap();
+    assert_eq!(witnesses[0], "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
 }
+
+#[test]
+fn test_udt_pay_with_acp_to_pw_lock_address() {
+    let resp = post_http_request(
+        r#"{
+        "id": 42,
+        "jsonrpc": "2.0",
+        "method": "build_transfer_transaction",
+        "params": [
+            {
+                "asset_info": {
+                    "asset_type": "UDT",
+                    "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
+                },
+                "from": {
+                    "items": [
+                        {
+                            "type": "Address",
+                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                        }
+                    ],
+                    "source": "Free"
+                },
+                "to": {
+                    "to_infos": [
+                        {
+                            "address": "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv",
+                            "amount": "5"
+                        }
+                    ],
+                    "mode": "PayWithAcp"
+                },
+                "pay_fee": null,
+                "change": null,
+                "fee_rate": null,
+                "since": {
+                    "flag": "Absolute",
+                    "type_": "BlockNumber",
+                    "value": 6000000
+                }
+            }
+        ]
+    }"#,
+    );
+    let r = &resp["result"];
+    let tx = &r["tx_view"];
+
+    let inputs = &tx["inputs"].as_array().unwrap();
+    let outputs = &tx["outputs"].as_array().unwrap();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(outputs.len(), 2);
+
+    let receiver_output_index = outputs
+        .iter()
+        .position(|output| output["lock"]["args"] == "0xadabffb9c27cb4af100ce7bca6903315220e87a2")
+        .unwrap();
+    assert_eq!(
+        tx["outputs_data"][receiver_output_index],
+        "0x05000000000000000000000000000000"
+    );
+    let receiver_output = outputs
+        .iter()
+        .find(|output| output["lock"]["args"] == "0xadabffb9c27cb4af100ce7bca6903315220e87a2")
+        .unwrap();
+    assert_eq!(receiver_output["capacity"], "0x34e62ce00");
+
+    let sender_output_index = outputs
+        .iter()
+        .position(|output| output["lock"]["args"] == "0xfa22aa0aaf155a6c816634c61512046b08923111")
+        .unwrap();
+    assert_eq!(
+        tx["outputs_data"][sender_output_index],
+        "0x9b000000000000000000000000000000"
+    );
+    let sender_output = outputs
+        .iter()
+        .find(|output| output["lock"]["args"] == "0xfa22aa0aaf155a6c816634c61512046b08923111")
+        .unwrap();
+    assert_eq!(sender_output["capacity"], "0xea2e5a052f");
+
+    let witnesses = &tx["witnesses"].as_array().unwrap();
+    assert_eq!(witnesses[0], "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+}
+
+#[test]
+fn test_udt_pay_with_acp_to_cheque_address() {
+    let resp = post_http_request(
+        r#"{
+        "id": 42,
+        "jsonrpc": "2.0",
+        "method": "build_transfer_transaction",
+        "params": [
+            {
+                "asset_info": {
+                    "asset_type": "UDT",
+                    "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
+                },
+                "from": {
+                    "items": [
+                        {
+                            "type": "Address",
+                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                        }
+                    ],
+                    "source": "Free"
+                },
+                "to": {
+                    "to_infos": [
+                        {
+                            "address": "ckt1qpsdtuu7lnjqn3v8ew02xkwwlh4dv5x2z28shkwt8p2nfruccux4kq29yywse6zu05ez3s64xmtdkl6074rac6zh7h2ln2w035d2lnh32ylk5ydmjq5ypwqs4asnr",
+                            "amount": "5"
+                        }
+                    ],
+                    "mode": "PayWithAcp"
+                },
+                "pay_fee": null,
+                "change": null,
+                "fee_rate": null,
+                "since": {
+                    "flag": "Absolute",
+                    "type_": "BlockNumber",
+                    "value": 6000000
+                }
+            }
+        ]
+    }"#,
+    );
+    
+    assert_ne!(resp["error"], Value::Null); // Unsupport lock script
+}
+
 
 #[test]
 fn test_ckb_pay_fee() {

--- a/tests/tests/rpc/get_account_info.rs
+++ b/tests/tests/rpc/get_account_info.rs
@@ -1,0 +1,47 @@
+use super::common::post_http_request;
+
+#[test]
+fn test_get_account_info_by_secp_address() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Address",
+                "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 1);
+}
+
+#[test]
+fn test_get_account_info_by_acp_address() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Address",
+                "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 1);
+}

--- a/tests/tests/rpc/get_account_info.rs
+++ b/tests/tests/rpc/get_account_info.rs
@@ -21,6 +21,8 @@ fn test_get_account_info_by_secp_address() {
     );
     let r = &resp["result"];
     assert_eq!(r["account_number"], 1);
+    assert_eq!(r["account_type"], "Acp".to_string());
+    assert_eq!(r["account_address"], "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn".to_string());
 }
 
 #[test]
@@ -44,4 +46,31 @@ fn test_get_account_info_by_acp_address() {
     );
     let r = &resp["result"];
     assert_eq!(r["account_number"], 1);
+    assert_eq!(r["account_type"], "Acp".to_string());
+    assert_eq!(r["account_address"], "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn".to_string());
+}
+
+#[test]
+fn test_get_account_info_by_pw_lock_address() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Address",
+                "value": "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 3);
+    assert_eq!(r["account_type"], "PwLock".to_string());
+    assert_eq!(r["account_address"], "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv".to_string());
 }

--- a/tests/tests/rpc/get_account_info.rs
+++ b/tests/tests/rpc/get_account_info.rs
@@ -1,4 +1,55 @@
 use super::common::post_http_request;
+use serde_json::Value;
+
+#[test]
+fn test_get_account_info_by_ckb_identity() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Identity",
+                "value": "0x00fa22aa0aaf155a6c816634c61512046b08923111"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 1);
+    assert_eq!(r["account_type"], "Acp".to_string());
+    assert_eq!(r["account_address"], "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn".to_string());
+}
+
+#[test]
+fn test_get_account_info_by_pw_lock_identity() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Identity",
+                "value": "0x01adabffb9c27cb4af100ce7bca6903315220e87a2"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 3);
+    assert_eq!(r["account_type"], "PwLock".to_string());
+    assert_eq!(r["account_address"], "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv".to_string());
+}
 
 #[test]
 fn test_get_account_info_by_secp_address() {
@@ -73,4 +124,51 @@ fn test_get_account_info_by_pw_lock_address() {
     assert_eq!(r["account_number"], 3);
     assert_eq!(r["account_type"], "PwLock".to_string());
     assert_eq!(r["account_address"], "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv".to_string());
+}
+
+#[test]
+fn test_get_account_info_by_cheque_address() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Address",
+                "value": "ckt1qpsdtuu7lnjqn3v8ew02xkwwlh4dv5x2z28shkwt8p2nfruccux4kq29yywse6zu05ez3s64xmtdkl6074rac6zh7h2ln2w035d2lnh32ylk5ydmjq5ypwqs4asnr"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    assert_ne!(resp["error"], Value::Null);
+}
+
+#[test]
+fn test_get_account_info_by_record() {
+    let resp = post_http_request(
+        r#"{
+        "jsonrpc": "2.0",
+        "method": "get_account_info",
+        "params": [{
+            "item": {
+                "type": "Record",
+                "value": "3eb0a1974dd6a2b6c3ba220169cef6eec21e94d2267fab9a4e810accc693c8ed0000000000636b7431717136706e6777716e366539766c6d393274683834726b306c346a703268386c757263686a6d6e7776386b71337274357073663476713036793234713474633474666b677a6533356363323379707274707a66727a79677370746b7a6e"
+            },
+            "asset_info": {
+                "asset_type": "UDT",
+                "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd" 
+            }
+        }],
+        "id": 42
+    }"#,
+    );
+    let r = &resp["result"];
+    assert_eq!(r["account_number"], 1);
+    assert_eq!(r["account_type"], "Acp".to_string());
+    assert_eq!(r["account_address"], "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn".to_string());
 }

--- a/tests/tests/rpc/get_account_info.rs
+++ b/tests/tests/rpc/get_account_info.rs
@@ -46,7 +46,7 @@ fn test_get_account_info_by_pw_lock_identity() {
     }"#,
     );
     let r = &resp["result"];
-    assert_eq!(r["account_number"], 3);
+    assert_eq!(r["account_number"], 4);
     assert_eq!(r["account_type"], "PwLock".to_string());
     assert_eq!(r["account_address"], "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv".to_string());
 }
@@ -121,7 +121,7 @@ fn test_get_account_info_by_pw_lock_address() {
     }"#,
     );
     let r = &resp["result"];
-    assert_eq!(r["account_number"], 3);
+    assert_eq!(r["account_number"], 4);
     assert_eq!(r["account_type"], "PwLock".to_string());
     assert_eq!(r["account_address"], "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv".to_string());
 }

--- a/tests/tests/rpc/mod.rs
+++ b/tests/tests/rpc/mod.rs
@@ -2,6 +2,7 @@ mod build_adjust_account_transaction;
 mod build_simple_transfer_transaction;
 mod build_transfer_transaction;
 pub mod common;
+mod get_account_info;
 mod get_balance;
 mod get_block_info;
 mod get_db;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
- add new transfer mode `PayWithAcp`: In the new `Paywithacp` mode, when transferring UDT assets, the CKBytes provided by the sender will belongs to the receiver. This is the difference from the `HoldByFrom` mode implemented by cheque lock.
- add new rpc `get_account_info`: with this rpc, you can check whether the receiver has a udt account before transferring udt. If there is, you can use the most convenient `HoldByTo` mode, if not, you can use `HoldbyFrom` or `PayWithAcp` mode according to the situation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

