### PR TITLE
refactor(rpc): replace Type Mode with Type OutputCapacityProvider

### DIFF
--- a/core/rpc/core/src/impl/adjust_account.rs
+++ b/core/rpc/core/src/impl/adjust_account.rs
@@ -13,7 +13,7 @@ use core_ckb_client::CkbRpc;
 use core_rpc_types::consts::{ckb, DEFAULT_FEE_RATE, STANDARD_SUDT_CAPACITY};
 use core_rpc_types::{
     AccountType, AdjustAccountPayload, AssetType, GetAccountInfoPayload, GetAccountInfoResponse,
-    Item, JsonItem, PayFee, ScriptGroup, TransactionCompletionResponse,
+    Item, JsonItem, ScriptGroup, TransactionCompletionResponse,
 };
 use num_traits::Zero;
 
@@ -144,7 +144,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             from,
             vec![],
             None,
-            PayFee::From,
+            None,
             fixed_fee,
             transfer_components,
         )

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -5,7 +5,7 @@ use ckb_dao_utils::extract_dao_data;
 use ckb_types::core::{BlockNumber, Capacity, EpochNumberWithFraction, RationalU256};
 use ckb_types::{bytes::Bytes, packed, prelude::*, H160, H256, U256};
 use common::address::{is_acp, is_pw_lock, is_secp256k1};
-use common::hash::blake2b_256_to_160;
+use common::hash::{blake2b_160, blake2b_256_to_160};
 use common::lazy::{
     ACP_CODE_HASH, CHEQUE_CODE_HASH, DAO_CODE_HASH, PW_LOCK_CODE_HASH, SECP256K1_CODE_HASH,
     SUDT_CODE_HASH,
@@ -2673,6 +2673,13 @@ pub fn to_since(config: SinceConfig) -> InnerResult<u64> {
         .into());
     }
     Ok((since << 56) + value)
+}
+
+pub fn build_cheque_args(receiver_address: Address, sender_address: Address) -> packed::Bytes {
+    let mut ret = blake2b_160(address_to_script(receiver_address.payload()).as_slice()).to_vec();
+    let sender = blake2b_160(address_to_script(sender_address.payload()).as_slice());
+    ret.extend_from_slice(&sender);
+    ret.pack()
 }
 
 pub(crate) fn check_same_enum_value(items: &[JsonItem]) -> InnerResult<()> {

--- a/core/rpc/core/src/tests/rpc_test.rs
+++ b/core/rpc/core/src/tests/rpc_test.rs
@@ -8,8 +8,8 @@ use common::{Address, DetailedCell, NetworkType, Order, PaginationRequest, Range
 use core_rpc_types::lazy::{CURRENT_BLOCK_NUMBER, CURRENT_EPOCH_NUMBER};
 use core_rpc_types::{
     indexer, AssetInfo, AssetType, Balance, DaoClaimPayload, DaoWithdrawPayload, ExtraType,
-    From as From2, GetBalancePayload, GetBlockInfoPayload, Identity, IdentityFlag, Item, JsonItem,
-    Mode, Record, SinceConfig, SinceFlag, SinceType, To, ToInfo, TransactionInfo,
+    GetBalancePayload, GetBlockInfoPayload, Identity, IdentityFlag, Item, JsonItem, Record,
+    SinceConfig, SinceFlag, SinceType, ToInfo, TransactionInfo,
 };
 use tokio::test;
 

--- a/core/rpc/core/src/tests/utils_test.rs
+++ b/core/rpc/core/src/tests/utils_test.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::r#impl::utils::{self};
+use crate::r#impl::utils::{self, calculate_cell_capacity};
 use ckb_jsonrpc_types::OutPoint;
 use core_rpc_types::{JsonItem, SinceConfig, SinceFlag, SinceType};
 
 use ckb_types::core::EpochNumberWithFraction;
 
-#[tokio::test]
-async fn test_is_dao_withdraw_unlock() {
+#[test]
+fn test_is_dao_withdraw_unlock() {
     let deposit_epoch = RationalU256::from_u256(0u64.into());
     let withdraw_epoch = RationalU256::from_u256(100u64.into());
     let tip_epoch = RationalU256::from_u256(180u64.into());
@@ -70,8 +70,8 @@ async fn test_is_dao_withdraw_unlock() {
     assert!(res);
 }
 
-#[tokio::test]
-async fn test_calculate_unlock_epoch_number() {
+#[test]
+fn test_calculate_unlock_epoch_number() {
     let deposit_epoch = EpochNumberWithFraction::new(2, 648, 1677);
     let withdraw_epoch = EpochNumberWithFraction::new(47, 382, 1605);
     let unlock_epoch_number = utils::calculate_unlock_epoch_number(
@@ -95,8 +95,8 @@ async fn test_calculate_unlock_epoch_number() {
     );
 }
 
-#[tokio::test]
-async fn test_epoch_number_into_u256() {
+#[test]
+fn test_epoch_number_into_u256() {
     let epoch = EpochNumberWithFraction::new(2, 648, 1677).to_rational();
     let epoch_rebuild = RationalU256::from_u256(epoch.clone().into_u256());
     assert_ne!(epoch, epoch_rebuild);
@@ -106,8 +106,8 @@ async fn test_epoch_number_into_u256() {
     assert_eq!(epoch_number_rational_u256, epoch_number.to_rational());
 }
 
-#[tokio::test]
-async fn test_to_since() {
+#[test]
+fn test_to_since() {
     let deposit_epoch = EpochNumberWithFraction::new(2, 648, 1677);
     let withdraw_epoch = EpochNumberWithFraction::new(47, 382, 1605);
     let unlock_epoch_number = utils::calculate_unlock_epoch_number(
@@ -123,8 +123,8 @@ async fn test_to_since() {
     assert_eq!(0x20068d02880000b6u64, since.unwrap());
 }
 
-#[tokio::test]
-async fn test_check_same_enum_value() {
+#[test]
+fn test_check_same_enum_value() {
     let items = vec![];
     let ret = utils::check_same_enum_value(&items);
     assert!(ret.is_ok());
@@ -158,8 +158,8 @@ async fn test_check_same_enum_value() {
     assert!(ret.is_err());
 }
 
-#[tokio::test]
-async fn test_dedup_items() {
+#[test]
+fn test_dedup_items() {
     let a1 = JsonItem::Identity("abc".to_string());
     let b1 = JsonItem::Identity("bcd".to_string());
     let c1 = JsonItem::OutPoint(OutPoint {
@@ -205,8 +205,8 @@ async fn test_dedup_items() {
     );
 }
 
-#[tokio::test]
-async fn test_dedup_items_identity() {
+#[test]
+fn test_dedup_items_identity() {
     let a = JsonItem::Identity("bcd".to_string());
     let b = JsonItem::Identity("bcd".to_string());
     let c = JsonItem::Identity("abc".to_string());
@@ -224,8 +224,8 @@ async fn test_dedup_items_identity() {
     );
 }
 
-#[tokio::test]
-async fn test_calculate_the_percentage() {
+#[test]
+fn test_calculate_the_percentage() {
     assert_eq!(
         "0.00000%".to_string(),
         utils::calculate_the_percentage(0, 0)
@@ -278,4 +278,15 @@ async fn test_calculate_the_percentage() {
         "150.00000%".to_string(),
         utils::calculate_the_percentage(3, 2)
     );
+}
+
+#[test]
+fn test_calculate_cell_capacity() {
+    let address = Address::from_str("ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqcydzyt").unwrap();
+    let capacity = calculate_cell_capacity(
+        &address_to_script(address.payload()),
+        &packed::ScriptOpt::default(),
+        Capacity::bytes(0).expect("generate capacity"),
+    );
+    assert_eq!(6100000000, capacity);
 }

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -151,13 +151,6 @@ pub enum TransactionStatus {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum Mode {
-    HoldByFrom,
-    HoldByTo,
-    PayWithAcp,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum SinceFlag {
     Relative,
     Absolute,
@@ -432,7 +425,8 @@ impl TransactionCompletionResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct SudtIssuePayload {
     pub owner: String,
-    pub to: To,
+    pub to: Vec<ToInfo>,
+    pub output_capacity_provider: Option<OutputCapacityProvider>,
     pub pay_fee: Option<JsonItem>,
     pub fee_rate: Option<Uint64>,
     pub since: Option<SinceConfig>,
@@ -463,36 +457,32 @@ impl ScriptGroup {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum PayFee {
-    From,
-    To,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TransferPayload {
     pub asset_info: AssetInfo,
-    pub from: From,
-    pub to: To,
-    pub pay_fee: PayFee,
+    pub from: Vec<JsonItem>,
+    pub to: Vec<ToInfo>,
+    pub output_capacity_provider: Option<OutputCapacityProvider>,
+    pub pay_fee: Option<PayFee>,
     pub fee_rate: Option<Uint64>,
     pub since: Option<SinceConfig>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub struct From {
-    pub items: Vec<JsonItem>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub struct To {
-    pub to_infos: Vec<ToInfo>,
-    pub mode: Mode,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ToInfo {
     pub address: String,
     pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq, Copy)]
+pub enum OutputCapacityProvider {
+    From,
+    To,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum PayFee {
+    From,
+    To,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -528,7 +518,7 @@ pub struct Extension {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DaoDepositPayload {
-    pub from: From,
+    pub from: Vec<JsonItem>,
     pub to: Option<String>,
     pub amount: Uint64,
     pub fee_rate: Option<Uint64>,

--- a/integration/src/tests/build_adjust_account_transaction.rs
+++ b/integration/src/tests/build_adjust_account_transaction.rs
@@ -81,7 +81,7 @@ fn test_adjust_account_pw_lock() {
     // account number: 1
     prepare_account(udt_hash, &pw_lock_address, &address, &address_pk, Some(1)).unwrap();
 
-    let response = mercury_client.get_balance(payload.clone()).unwrap();
+    let response = mercury_client.get_balance(payload).unwrap();
     assert_eq!(response.balances.len(), 1);
     assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
 

--- a/integration/src/tests/build_dao_related_transaction.rs
+++ b/integration/src/tests/build_dao_related_transaction.rs
@@ -8,8 +8,8 @@ use crate::utils::rpc_client::MercuryRpcClient;
 use crate::utils::signer::sign_transaction;
 
 use core_rpc_types::{
-    AssetInfo, AssetType, DaoClaimPayload, DaoDepositPayload, DaoWithdrawPayload, From,
-    GetBalancePayload, JsonItem, Mode, PayFee, To, ToInfo, TransferPayload,
+    AssetInfo, AssetType, DaoClaimPayload, DaoDepositPayload, DaoWithdrawPayload,
+    GetBalancePayload, JsonItem, OutputCapacityProvider, ToInfo, TransferPayload,
 };
 
 use std::collections::HashSet;
@@ -26,9 +26,7 @@ fn test_dao() {
 
     // deposit
     let payload = DaoDepositPayload {
-        from: From {
-            items: vec![JsonItem::Address(address.to_string())],
-        },
+        from: vec![JsonItem::Address(address.to_string())],
         to: None,
         amount: 200_0000_0000.into(),
         fee_rate: None,
@@ -107,9 +105,7 @@ fn test_dao_pool_money() {
 
     // deposit
     let payload = DaoDepositPayload {
-        from: From {
-            items: vec![JsonItem::Address(address.to_string())],
-        },
+        from: vec![JsonItem::Address(address.to_string())],
         to: None,
         amount: 200_0000_0000.into(),
         fee_rate: None,
@@ -151,17 +147,13 @@ fn test_dao_pool_money() {
     let (to_address, _) = generate_rand_secp_address_pk_pair();
     let transfer_payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: From {
-            items: vec![JsonItem::Address(address.to_string())],
-        },
-        to: To {
-            to_infos: vec![ToInfo {
-                address: to_address.to_string(),
-                amount: 200_0000_0000u128.into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
-        pay_fee: PayFee::From,
+        from: vec![JsonItem::Address(address.to_string())],
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 200_0000_0000u128.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
         fee_rate: None,
         since: None,
     };

--- a/integration/src/tests/build_simple_transfer_transaction.rs
+++ b/integration/src/tests/build_simple_transfer_transaction.rs
@@ -79,10 +79,10 @@ fn test_simple_transfer_ckb() {
 }
 
 inventory::submit!(IntegrationTest {
-    name: "test_simple_transfer_udt_hold_by_to",
-    test_fn: test_simple_transfer_udt_hold_by_to
+    name: "test_simple_transfer_udt_to_provide_capacity",
+    test_fn: test_simple_transfer_udt_to_provide_capacity
 });
-fn test_simple_transfer_udt_hold_by_to() {
+fn test_simple_transfer_udt_to_provide_capacity() {
     // prepare udt
     issue_udt_1().unwrap();
     let udt_hash = UDT_1_HASH.get().unwrap();
@@ -159,10 +159,10 @@ fn test_simple_transfer_udt_hold_by_to() {
 }
 
 inventory::submit!(IntegrationTest {
-    name: "test_simple_transfer_udt_hold_by_from",
-    test_fn: test_simple_transfer_udt_hold_by_from
+    name: "test_simple_transfer_udt_from_provide_capacity",
+    test_fn: test_simple_transfer_udt_from_provide_capacity
 });
-fn test_simple_transfer_udt_hold_by_from() {
+fn test_simple_transfer_udt_from_provide_capacity() {
     // prepare udt
     issue_udt_1().unwrap();
 

--- a/integration/src/tests/build_sudt_issue_transaction.rs
+++ b/integration/src/tests/build_sudt_issue_transaction.rs
@@ -11,10 +11,10 @@ use core_rpc_types::{AssetInfo, GetBalancePayload, JsonItem};
 use std::collections::HashSet;
 
 inventory::submit!(IntegrationTest {
-    name: "test_issue_udt_hold_by_from",
-    test_fn: test_issue_udt_hold_by_from
+    name: "test_issue_udt_from_provide_capacity",
+    test_fn: test_issue_udt_from_provide_capacity
 });
-fn test_issue_udt_hold_by_from() {
+fn test_issue_udt_from_provide_capacity() {
     // prepare
     let (owner_address, owner_pk, _) =
         prepare_secp_address_with_ckb_capacity(250_0000_0000).expect("prepare ckb");

--- a/integration/src/tests/build_transfer_transaction_ckb_pw.rs
+++ b/integration/src/tests/build_transfer_transaction_ckb_pw.rs
@@ -6,33 +6,29 @@ use crate::utils::rpc_client::MercuryRpcClient;
 use crate::utils::signer::sign_transaction;
 
 use core_rpc_types::{
-    AssetInfo, AssetType, From, GetBalancePayload, JsonItem, Mode, PayFee, To, ToInfo,
+    AssetInfo, AssetType, GetBalancePayload, JsonItem, OutputCapacityProvider, PayFee, ToInfo,
     TransferPayload,
 };
 
 use std::collections::HashSet;
 
 inventory::submit!(IntegrationTest {
-    name: "test_transfer_ckb_hold_by_from_pw",
-    test_fn: test_transfer_ckb_hold_by_from_pw
+    name: "test_transfer_ckb_from_provide_capacity_pw",
+    test_fn: test_transfer_ckb_from_provide_capacity_pw
 });
-fn test_transfer_ckb_hold_by_from_pw() {
+fn test_transfer_ckb_from_provide_capacity_pw() {
     let (from_address, from_pk, _) =
         prepare_pw_address_with_capacity(200_0000_0000).expect("prepare ckb");
     let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
     let payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: From {
-            items: vec![JsonItem::Address(from_address.to_string())],
-        },
-        to: To {
-            to_infos: vec![ToInfo {
-                address: to_address.to_string(),
-                amount: 100_0000_0000u128.into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
-        pay_fee: PayFee::From,
+        from: vec![JsonItem::Address(from_address.to_string())],
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 100_0000_0000u128.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
         fee_rate: None,
         since: None,
     };
@@ -80,26 +76,23 @@ fn test_transfer_ckb_hold_by_from_pw() {
 }
 
 inventory::submit!(IntegrationTest {
-    name: "test_transfer_ckb_hold_by_from_pw_pay_fee_to",
-    test_fn: test_transfer_ckb_hold_by_from_pw_pay_fee_to
+    name: "test_transfer_ckb_from_provide_capacity_pw_pay_fee_to",
+    test_fn: test_transfer_ckb_from_provide_capacity_pw_pay_fee_to
 });
-fn test_transfer_ckb_hold_by_from_pw_pay_fee_to() {
+fn test_transfer_ckb_from_provide_capacity_pw_pay_fee_to() {
     let (from_address, from_pk, _) =
         prepare_pw_address_with_capacity(200_0000_0000).expect("prepare ckb");
     let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
     let payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: From {
-            items: vec![JsonItem::Address(from_address.to_string())],
-        },
-        to: To {
-            to_infos: vec![ToInfo {
-                address: to_address.to_string(),
-                amount: 100_0000_0000u128.into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
-        pay_fee: PayFee::To,
+        from: vec![JsonItem::Address(from_address.to_string())],
+
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 100_0000_0000u128.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: Some(PayFee::To),
         fee_rate: None,
         since: None,
     };

--- a/integration/src/utils/instruction.rs
+++ b/integration/src/utils/instruction.rs
@@ -6,8 +6,8 @@ use crate::const_definition::{
     UDT_1_HOLDER_ACP_ADDRESS, UDT_1_HOLDER_ACP_ADDRESS_PK,
 };
 use crate::utils::address::{
-    build_acp_address, generate_rand_pw_address_pk_pair, generate_rand_secp_address_pk_pair,
-    get_udt_hash_by_owner,
+    build_acp_address, build_cheque_address, generate_rand_pw_address_pk_pair,
+    generate_rand_secp_address_pk_pair, get_udt_hash_by_owner,
 };
 use crate::utils::rpc_client::{CkbRpcClient, MercuryRpcClient};
 use crate::utils::signer::sign_transaction;
@@ -21,8 +21,8 @@ use common::lazy::{
 };
 use common::Address;
 use core_rpc_types::{
-    AdjustAccountPayload, AssetInfo, AssetType, From, IOType, JsonItem, Mode, PayFee,
-    SimpleTransferPayload, SudtIssuePayload, To, ToInfo, TransferPayload,
+    AdjustAccountPayload, AssetInfo, AssetType, IOType, JsonItem, OutputCapacityProvider,
+    SimpleTransferPayload, SudtIssuePayload, ToInfo, TransferPayload,
 };
 
 use std::collections::HashSet;
@@ -233,17 +233,13 @@ pub(crate) fn prepare_secp_address_with_ckb_capacity(
     let (address, pk) = generate_rand_secp_address_pk_pair();
     let payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: From {
-            items: vec![JsonItem::Address(GENESIS_BUILT_IN_ADDRESS_1.to_string())],
-        },
-        to: To {
-            to_infos: vec![ToInfo {
-                address: address.to_string(),
-                amount: (capacity as u128).into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
-        pay_fee: PayFee::From,
+        from: vec![JsonItem::Address(GENESIS_BUILT_IN_ADDRESS_1.to_string())],
+        to: vec![ToInfo {
+            address: address.to_string(),
+            amount: (capacity as u128).into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
         fee_rate: None,
         since: None,
     };
@@ -278,15 +274,15 @@ pub(crate) fn issue_udt_with_cheque(
     to_address: &Address,
     udt_amount: u128,
 ) -> Result<H256> {
+    let cheque_address =
+        build_cheque_address(to_address, owner_address).expect("build cheque address");
     let payload = SudtIssuePayload {
         owner: owner_address.to_string(),
-        to: To {
-            to_infos: vec![ToInfo {
-                address: to_address.to_string(),
-                amount: udt_amount.into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
+        to: vec![ToInfo {
+            address: cheque_address.to_string(),
+            amount: udt_amount.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
         pay_fee: None,
         fee_rate: None,
         since: None,
@@ -332,17 +328,13 @@ pub(crate) fn prepare_pw_address_with_capacity(capacity: u64) -> Result<(Address
     let (address, pk) = generate_rand_pw_address_pk_pair();
     let payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: From {
-            items: vec![JsonItem::Address(GENESIS_BUILT_IN_ADDRESS_1.to_string())],
-        },
-        to: To {
-            to_infos: vec![ToInfo {
-                address: address.to_string(),
-                amount: (capacity as u128).into(),
-            }],
-            mode: Mode::HoldByFrom,
-        },
-        pay_fee: PayFee::From,
+        from: vec![JsonItem::Address(GENESIS_BUILT_IN_ADDRESS_1.to_string())],
+        to: vec![ToInfo {
+            address: address.to_string(),
+            amount: (capacity as u128).into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
         fee_rate: None,
         since: None,
     };

--- a/tests/tests/rpc/build_dao_deposit_transaction.rs
+++ b/tests/tests/rpc/build_dao_deposit_transaction.rs
@@ -10,15 +10,10 @@ fn test_dao_deposit_by_address() {
         "method": "build_dao_deposit_transaction",
         "params": [
             {
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
-                        }
-                    ],
-                    "source": "Free"
-                },
+                "from": [{
+                    "type": "Address",
+                    "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                }],
                 "to": null,
                 "amount": "0x4a817c800",
                 "fee_rate": null

--- a/tests/tests/rpc/build_simple_transfer_transaction.rs
+++ b/tests/tests/rpc/build_simple_transfer_transaction.rs
@@ -66,7 +66,6 @@ fn test_udt() {
                         "amount": "0x5"
                     }
                 ],
-                "change": null,
                 "fee_rate": null,
                 "since": null
             }

--- a/tests/tests/rpc/build_sudt_issue_transaction.rs
+++ b/tests/tests/rpc/build_sudt_issue_transaction.rs
@@ -12,17 +12,14 @@ fn test_address() {
         "params": [
             {
                 "owner": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9",
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x5f5e100"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "to": [
+                    {
+                        "address": "ckt1qqdpunl0xn6es2gx7azmqj870vggjer7sg6xqa8q7vkzan3xea43uqt6g2dxvxxjtdhfvfs0f67gwzgrcrfg3gj9yywse6zu05ez3s64xmtdkl6074rac6q3f7cvk",
+                        "amount": "0x5f5e100"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": null,
-                "change": null,
                 "fee_rate": "0x3e8",
                 "since": null
             }

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -258,7 +258,7 @@ fn test_udt_single_from_single_to() {
 }
 
 #[test]
-fn test_ckb_hold_by_to() {
+fn test_ckb_to_provide_capacity() {
     let resp = post_http_request(
         r#"{
         "id": 42,
@@ -270,24 +270,19 @@ fn test_ckb_hold_by_to() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "9650000000"
-                        }
-                    ],
-                    "mode": "HoldByTo"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "9650000000"
+                    }
+                ],
+                "output_capacity_provider": null,
                 "pay_fee": null,
                 "change": null,
                 "fee_rate": null,
@@ -304,53 +299,7 @@ fn test_ckb_hold_by_to() {
 }
 
 #[test]
-fn test_ckb_pay_with_acp() {
-    let resp = post_http_request(
-        r#"{
-        "id": 42,
-        "jsonrpc": "2.0",
-        "method": "build_transfer_transaction",
-        "params": [
-            {
-                "asset_info": {
-                    "asset_type": "CKB",
-                    "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-                },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "9650000000"
-                        }
-                    ],
-                    "mode": "PayWithAcp"
-                },
-                "pay_fee": null,
-                "change": null,
-                "fee_rate": null,
-                "since": {
-                    "flag": "Absolute",
-                    "type_": "BlockNumber",
-                    "value": 6000000
-                }
-            }
-        ]
-    }"#,
-    );
-    assert_ne!(resp["error"], Value::Null); // Unsupport transfer mode: PayWithAcp when transfer CKB
-}
-
-#[test]
-fn test_udt_pay_with_acp_to_secp_address() {
+fn test_udt_from_provide_capacity_to_acp_lock() {
     let resp = post_http_request(
         r#"{
         "id": 42,
@@ -428,7 +377,7 @@ fn test_udt_pay_with_acp_to_secp_address() {
 }
 
 #[test]
-fn test_udt_pay_with_acp_to_pw_lock_address() {
+fn test_udt_from_provide_capacity_to_pw_lock() {
     let resp = post_http_request(
         r#"{
         "id": 42,
@@ -503,53 +452,6 @@ fn test_udt_pay_with_acp_to_pw_lock_address() {
 
     let witnesses = &tx["witnesses"].as_array().unwrap();
     assert_eq!(witnesses[0], "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-}
-
-#[test]
-fn test_udt_pay_with_acp_to_cheque_address() {
-    let resp = post_http_request(
-        r#"{
-        "id": 42,
-        "jsonrpc": "2.0",
-        "method": "build_transfer_transaction",
-        "params": [
-            {
-                "asset_info": {
-                    "asset_type": "UDT",
-                    "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
-                },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qpsdtuu7lnjqn3v8ew02xkwwlh4dv5x2z28shkwt8p2nfruccux4kq29yywse6zu05ez3s64xmtdkl6074rac6zh7h2ln2w035d2lnh32ylk5ydmjq5ypwqs4asnr",
-                            "amount": "5"
-                        }
-                    ],
-                    "mode": "PayWithAcp"
-                },
-                "pay_fee": null,
-                "change": null,
-                "fee_rate": null,
-                "since": {
-                    "flag": "Absolute",
-                    "type_": "BlockNumber",
-                    "value": 6000000
-                }
-            }
-        ]
-    }"#,
-    );
-
-    assert_ne!(resp["error"], Value::Null); // Unsupport lock script
 }
 
 #[test]

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -15,24 +15,19 @@ fn test_ckb_single_from_single_to() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x23f2f5080"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "0x23f2f5080"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,
@@ -86,28 +81,23 @@ fn test_ckb_single_from_multiple_to() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x104c533c00"
-                        },
-                        {
-                            "address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqyerlanzmnkxtmd9ww9n7gr66k8jt4tclm9jnk",
-                            "amount": "0x4a817c800"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "0x104c533c00"
+                    },
+                    {
+                        "address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqyerlanzmnkxtmd9ww9n7gr66k8jt4tclm9jnk",
+                        "amount": "0x4a817c800"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,
@@ -167,30 +157,24 @@ fn test_ckb_multiple_from_single_to() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        },
-                        {
-                            "type": "Address",
-                            "value": "ckt1qyp05g42p2h32knvs9nrf3s4zgzxkzyjxygs4e29ue"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x1d202b24f00"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    },
+                    {
+                        "type": "Address",
+                        "value": "ckt1qyp05g42p2h32knvs9nrf3s4zgzxkzyjxygs4e29ue"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "0x1d202b24f00"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
-                "change": null,
                 "fee_rate": null,
                 "since": {
                     "flag": "Absolute",
@@ -226,26 +210,20 @@ fn test_udt_single_from_single_to() {
                     "asset_type": "UDT",
                     "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x5"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qqdpunl0xn6es2gx7azmqj870vggjer7sg6xqa8q7vkzan3xea43uqt6g2dxvxxjtdhfvfs0f67gwzgrcrfg3gj9yywse6zu05ez3s64xmtdkl6074rac6q3f7cvk",
+                        "amount": "0x5"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
-                "change": null,
                 "fee_rate": null,
                 "since": {
                     "flag": "Absolute",
@@ -384,24 +362,19 @@ fn test_udt_pay_with_acp_to_secp_address() {
                     "asset_type": "UDT",
                     "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x5"
-                        }
-                    ],
-                    "mode": "PayWithAcp"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qp3g8fre50846snkekf4jn0f7xp84wd4t3astv7j3exzuznfdnl06qv6e65dqy3kfslr3j2cdh4enhyqeqyawysf7sf4c",
+                        "amount": "0x5"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,
@@ -467,24 +440,19 @@ fn test_udt_pay_with_acp_to_pw_lock_address() {
                     "asset_type": "UDT",
                     "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv",
-                            "amount": "0x5"
-                        }
-                    ],
-                    "mode": "PayWithAcp"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqdd40lmnsnukjh3qr88hjnfqvc4yg8g0gskp8ffv",
+                        "amount": "0x5"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,
@@ -597,26 +565,20 @@ fn test_ckb_pay_fee() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x23f2f5080"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "0x23f2f5080"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "To",
-                "change": null,
                 "fee_rate": null,
                 "since": {
                     "flag": "Absolute",
@@ -660,24 +622,19 @@ fn test_ckb_single_from_single_to_identity() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Identity",
-                            "value": "0x00fa22aa0aaf155a6c816634c61512046b08923111"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
-                            "amount": "0x23f2f5080"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Identity",
+                        "value": "0x00fa22aa0aaf155a6c816634c61512046b08923111"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qyqf4n4g6qfrvnp78ry4sm0tn8wgpjqf6ufq74srld",
+                        "amount": "0x23f2f5080"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,
@@ -714,24 +671,19 @@ fn test_ckb_single_from_single_to_any_address() {
                     "asset_type": "CKB",
                     "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                 },
-                "from": {
-                    "items": [
-                        {
-                            "type": "Address",
-                            "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
-                        }
-                    ],
-                    "source": "Free"
-                },
-                "to": {
-                    "to_infos": [
-                        {
-                            "address": "ckt1qq56s9rnufyjfcu54y2g4v6hcfyjlm0k2fqcfzm6safe5ldec02r7qyz366atsthnl87z038a6lcqaqsq3gdkdd43kj5emkwvdd50astp578twzk",
-                            "amount": "0x23f2f5080"
-                        }
-                    ],
-                    "mode": "HoldByFrom"
-                },
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
+                "to": [
+                    {
+                        "address": "ckt1qq56s9rnufyjfcu54y2g4v6hcfyjlm0k2fqcfzm6safe5ldec02r7qyz366atsthnl87z038a6lcqaqsq3gdkdd43kj5emkwvdd50astp578twzk",
+                        "amount": "0x23f2f5080"
+                    }
+                ],
+                "output_capacity_provider": "From",
                 "pay_fee": "From",
                 "change": null,
                 "fee_rate": null,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Rpc Type Breaking Change：

- replace Type Mode with Type OutputCapacityProvider for ckb/udt transfer.
- remove Type From, To
- update affected structs: TransferPayload，DaoDepositPayload，SudtIssuePayload

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

Breaking Change

**Special notes for your reviewer**:

