### PR TITLE
refactor(rpc): update rpc type and enum

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -84,9 +84,10 @@ impl<T: Debug + Display> MercuryError<T> {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
 pub enum Order {
+    #[serde(alias = "asc")]
     Asc,
+    #[serde(alias = "desc")]
     Desc,
 }
 

--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -113,10 +113,10 @@ The error code ranges are as follows:
 
 - `get_balance(item, asset_infos, tip_block_number)`
   - `item`: [`JsonItem`](#type-jsonitem)
-  - `asset_infos`: `Array<`[`AssetInfo>`](#type-assetinfo)`>`
-  - `tip_block_number`: `BlockNumber|null`
+  - `asset_infos`: `Array<`[`AssetInfo`](#type-assetinfo)`>`
+  - `tip_block_number`: [`BlockNumber`](#type-blocknumber)`|null`
 - result
-  - `tip_block_number`: `BlockNumber`
+  - `tip_block_number`: [`BlockNumber`](#type-blocknumber)
   - `balances`: `Array<`[`Balance`](#type-balance)`>`
 
 **Usage**
@@ -401,7 +401,7 @@ echo '{
 - `query_transactions(item, asset_infos, extra, block_range, pagination, structure_type)`
   - `item`: [`JsonItem`](#type-jsonitem)
   - `asset_infos`: `Array<`[`AssetInfo>`](#type-assetinfo)`>`
-  - `extra`: `"DAO"|"Cellbase"| null`
+  - `extra`: `"Dao"|"Cellbase"|null`
   - `block_range`: [`Range`](#type-range)`|null`
   - `pagination`: [`PaginationRequest`](#type-paginationrequest)
   - `structure_type`: `"Native"|"DoubleEntry"`
@@ -774,7 +774,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x791359d5f872fc4e72185034da0becb5febce98b"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -786,7 +786,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x7c7f0ee1d582c385342367792946cff3767fe02f26fd7f07dba23ae3c65b28bc"
         }, 
-        "group_type": "TypeScript", 
+        "group_type": "Type", 
         "input_indices": [ ], 
         "output_indices": [
           "0x0"
@@ -942,7 +942,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x57ccb07be6875f61d93636b0ee11b675494627d2"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -1077,7 +1077,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x3f1573b44218d4c12a91919a58a863be415a2bc3"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -1265,7 +1265,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x3f1573b44218d4c12a91919a58a863be415a2bc3"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -1277,7 +1277,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x"
         }, 
-        "group_type": "TypeScript", 
+        "group_type": "Type", 
         "input_indices": [ ], 
         "output_indices": [
           "0x0"
@@ -1421,7 +1421,7 @@ echo '{
           "hash_type": "type", 
           "args": "0xc8f77049fe93a1f452716edc4a87000406a9ce56"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -1433,7 +1433,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x"
         }, 
-        "group_type": "TypeScript", 
+        "group_type": "Type", 
         "input_indices": [
           "0x0"
         ], 
@@ -1447,7 +1447,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x3f1573b44218d4c12a91919a58a863be415a2bc3"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x1"
         ], 
@@ -1604,7 +1604,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x202647fecc5b9d8cbdb4ae7167e40f5ab1e4baaf"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0", 
           "0x1", 
@@ -1620,7 +1620,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x"
         }, 
-        "group_type": "TypeScript", 
+        "group_type": "Type", 
         "input_indices": [
           "0x0", 
           "0x1", 
@@ -1981,7 +1981,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x5619a2b220d667c7be4cc44d9fd6a3aac20fa122"
         }, 
-        "group_type": "LockScript", 
+        "group_type": "Lock", 
         "input_indices": [
           "0x0"
         ], 
@@ -1993,7 +1993,7 @@ echo '{
           "hash_type": "type", 
           "args": "0x3ea6a19921331ac8a3f7ec6bcae80ef746884eb2cbf7f8c87df721a6bc879758"
         }, 
-        "group_type": "TypeScript", 
+        "group_type": "Type", 
         "input_indices": [ ], 
         "output_indices": [
           "0x0"
@@ -2157,13 +2157,13 @@ echo '{
 Fields
 
 - `type` (Type: `"Identity"|"Address"|"OutPoint"`): Specify the type of item.
-- `value` (Type: `string`|`string`|[`OutPoint`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-outpoint) ): Specify the value of item.
+- `value` (Type: `string` | `string` | [`OutPoint`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-outpoint) ): Specify the value of item.
 
 ### Type `AssetInfo`
 
 Fields
 
-- `asset_type` (Type: `"CKB"`|`"UDT"`): Specify the asset type.
+- `asset_type` (Type: `"CKB"` | `"UDT"`): Specify the asset type.
 - `udt_hash` (Type: `string`): Specify the hash of a UDT asset.
 
 ### Type `Balance`
@@ -2181,7 +2181,7 @@ Fields
 Fields
 
 - `from` (Type: `Uint64`): Specify the start block number of the range.
-- `to  ` (Type: `Uint64`): Specify the end block number of the range.
+- `to` (Type: `Uint64`): Specify the end block number of the range.
 
 ### Type `PaginationRequest`
 
@@ -2189,11 +2189,11 @@ This is a cursor-based pagination configuration.
 
 Fields
 
-- `cursor` (Type:`Uint64`|`null` ): Specify the beginning cursor for the query.
+- `cursor` (Type:`Uint64` | `null` ): Specify the beginning cursor for the query.
   - Start from the biggest cursor for descending order
   - Start from the smallest cursor for ascending order
-- `order  ` (Type: `"asc"`|`"desc"`): Specify the order of the returning data.
-- `limit` (Type: `Uint64`|`null` ): Specify the entry limit per page of the query.
+- `order` (Type: `"Asc"` | `"Desc"`): Specify the order of the returning data.
+- `limit` (Type: `Uint64` | `null` ): Specify the entry limit per page of the query.
 - `return_count` (Type: `bool`): Specify whether to return the total count.
 
 ### Type `BlockInfo`
@@ -2261,7 +2261,7 @@ Fields
 - `occupied` (Type: `Uint64`): Specify the amount of CKB that provides capacity.
 - `asset_info` (Type: [`AssetInfo`](#type-assetinfo)): Specify the asset type of the record.
 - `extra` (Type:  [`ExtraFilter`](#type-extrafilter)`|null`): Specify extra information of the record.
-- `block_number` (Type:`BlockNumber`): Block number.
+- `block_number` (Type: [`BlockNumber`](#type-blocknumber)): Block number.
 - `epoch_number` (Type: `Uint64`): Epoch value encoded.
 
 ### Type `ExtraFilter`
@@ -2275,7 +2275,7 @@ Fields
 
 Fields
 
-- `state`  (Type:[`DaoState`](#type-daoState)): Specify the state of a DAO operation.
+- `state`  (Type: [`DaoState`](#type-daoState)): Specify the state of a DAO operation.
 - `reward` (Type: `Uint64`): Specify the accumulate reward of a DAO operation.
 
 ### Type `DaoState`
@@ -2299,7 +2299,7 @@ A struct for signing on a raw transaction.
 Fields
 
 - `script`  (Type: [`Script`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-script)): Describes the lock script and type script for a cell.
-- `group_type`  (Type: `"LockScript"|"TypeScript"`): Group type.
+- `group_type`  (Type: `"Lock"|"Type"`): Group type.
 - `input_indices`   (Type: `Array<Uint32>`): 
 All input indices within this group.
 - `output_indices`  (Type: `Array<Uint32>`):

--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -279,7 +279,7 @@ echo '{
               "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
             }, 
             "extra": {
-              "type": "CellBase"
+              "type": "Cellbase"
             }, 
             "block_number": "0x7c2c1", 
             "epoch_number": "0x4d6036b00030b"
@@ -301,7 +301,7 @@ echo '{
   - `tx_hash`: `string`
 - result
   - `transaction`: [`TransactionInfo`](#type-transactioninfo)`|null`
-  - `status`: `"pending"|"proposed"|"committed"|"rejected"|"unknown"`
+  - `status`: `"Pending"|"Proposed"|"Committed"|"Rejected"|"Unknown"`
 
 **Usage**
 
@@ -315,11 +315,11 @@ To return the double-entry style transaction along with the status of a specifie
 
 - `transaction` - double-entry style transaction of the specified `tx_hash`.
 - `status`
-  - Status "pending" means the transaction is in the pool and not proposed yet.
-  - Status "proposed" means the transaction is in the pool and has been proposed.
-  - Status "committed" means the transaction has been committed to the canonical chain.
-  - Status "rejected" means the transaction has been rejected by the pool.
-  - Status "unknown" means the transaction was unknown for the pool.
+  - Status "Pending" means the transaction is in the pool and not proposed yet.
+  - Status "Proposed" means the transaction is in the pool and has been proposed.
+  - Status "Committed" means the transaction has been committed to the canonical chain.
+  - Status "Rejected" means the transaction has been rejected by the pool.
+  - Status "Unknown" means the transaction was unknown for the pool.
 
 **Examples**
 
@@ -361,7 +361,7 @@ echo '{
             "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
           }, 
           "extra": {
-            "type": "Freeze"
+            "type": "Frozen"
           }, 
           "block_number": "0x342814", 
           "epoch_number": "0x708028c000ca2"
@@ -380,7 +380,7 @@ echo '{
             "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
           }, 
           "extra": {
-            "type": "Freeze"
+            "type": "Frozen"
           }, 
           "block_number": "0x3428a9", 
           "epoch_number": "0x7080321000ca2"
@@ -390,7 +390,7 @@ echo '{
       "burn": [ ], 
       "timestamp": "0x17d18a1e595"
     }, 
-    "status": "committed"
+    "status": "Committed"
   }, 
   "id": 42
 }
@@ -2242,7 +2242,7 @@ Transaction rich status.
 
 Fields
 
-- `status` (Type: [`Status`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-status)): The transaction status, allowed values: "pending", "proposed" "committed" "unknown" and "rejected".
+- `status` (Type: [`Status`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-status)): The transaction status, allowed values: "Pending", "Proposed" "Committed" "Unknown" and "Rejected".
 - `block_hash` (Type: [`H256`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-h256) `|` `null`): Specify the block hash of the block which has committed this transaction in the canonical chain.
 - `reason` (Type: `string` `|` `null`): Specify the reason why the transaction is rejected.
 - `timestamp` (Type: `Uint64` `|` `null`): Specify the timestamp of the block in which the transaction is packaged.
@@ -2268,7 +2268,7 @@ Fields
 
 Fields
 
-- `type` (Type: `"Dao"|"Cellbase"|"Freeze"`): Specify the type of extra filter.
+- `type` (Type: `"Dao"|"Cellbase"|"Frozen"`): Specify the type of extra filter.
 - `value` (Type: [`DaoInfo`](#type-daoinfo)`|null`) : Specify the value of extra filter.
 
 ### Type `DaoInfo`

--- a/core/rpc/core/src/impl.rs
+++ b/core/rpc/core/src/impl.rs
@@ -18,8 +18,8 @@ use common::lazy::{
 };
 use common::utils::ScriptInfo;
 use common::{
-    async_trait, hash::blake2b_160, Address, AddressPayload, Context, NetworkType, ACP, CHEQUE,
-    DAO, PW_LOCK, SECP256K1, SUDT,
+    async_trait, hash::blake2b_160, Address, AddressPayload, Context, NetworkType, Order, ACP,
+    CHEQUE, DAO, PW_LOCK, SECP256K1, SUDT,
 };
 use core_ckb_client::CkbRpc;
 use core_rpc_types::error::MercuryRpcError;
@@ -185,7 +185,7 @@ impl<C: CkbRpc> MercuryRpcServer for MercuryRpcImpl<C> {
     async fn get_cells(
         &self,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: Uint64,
         after_cursor: Option<Uint64>,
     ) -> RpcResult<indexer::PaginationResponse<indexer::Cell>> {
@@ -212,7 +212,7 @@ impl<C: CkbRpc> MercuryRpcServer for MercuryRpcImpl<C> {
     async fn get_transactions(
         &self,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: Uint64,
         after_cursor: Option<Uint64>,
     ) -> RpcResult<indexer::PaginationResponse<indexer::Transaction>> {

--- a/core/rpc/core/src/impl/build_tx.rs
+++ b/core/rpc/core/src/impl/build_tx.rs
@@ -1489,20 +1489,20 @@ fn build_script_groups(
     tx_inputs.enumerate().for_each(|(i, cell)| {
         let lock_script = cell.cell_output.lock();
         let lock_group_entry = script_groups
-            .entry((lock_script.clone(), ScriptGroupType::LockScript))
+            .entry((lock_script.clone(), ScriptGroupType::Lock))
             .or_insert_with(|| ScriptGroup {
                 script: lock_script.into(),
-                group_type: ScriptGroupType::LockScript,
+                group_type: ScriptGroupType::Lock,
                 input_indices: vec![],
                 output_indices: vec![],
             });
         lock_group_entry.input_indices.push((i as u32).into());
         if let Some(type_script) = cell.cell_output.type_().to_opt() {
             let type_group_entry = script_groups
-                .entry((type_script.clone(), ScriptGroupType::TypeScript))
+                .entry((type_script.clone(), ScriptGroupType::Type))
                 .or_insert_with(|| ScriptGroup {
                     script: type_script.into(),
-                    group_type: ScriptGroupType::TypeScript,
+                    group_type: ScriptGroupType::Type,
                     input_indices: vec![],
                     output_indices: vec![],
                 });
@@ -1512,10 +1512,10 @@ fn build_script_groups(
     tx_outputs.enumerate().for_each(|(i, cell)| {
         if let Some(type_script) = cell.type_().to_opt() {
             let type_group_entry = script_groups
-                .entry((type_script.clone(), ScriptGroupType::TypeScript))
+                .entry((type_script.clone(), ScriptGroupType::Type))
                 .or_insert_with(|| ScriptGroup {
                     script: type_script.into(),
-                    group_type: ScriptGroupType::TypeScript,
+                    group_type: ScriptGroupType::Type,
                     input_indices: vec![],
                     output_indices: vec![],
                 });
@@ -1533,7 +1533,7 @@ fn build_witnesses(
 ) -> Vec<packed::Bytes> {
     let mut witnesses = vec![packed::Bytes::default(); inputs_len];
     for script_group in script_groups {
-        if script_group.group_type == ScriptGroupType::TypeScript {
+        if script_group.group_type == ScriptGroupType::Type {
             continue;
         }
         let input_index: u32 = script_group.input_indices[0].into();

--- a/core/rpc/core/src/impl/query.rs
+++ b/core/rpc/core/src/impl/query.rs
@@ -213,12 +213,11 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         &self,
         ctx: Context,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: u64,
         after_cursor: Option<u64>,
     ) -> InnerResult<indexer::PaginationResponse<indexer::Cell>> {
-        let pagination =
-            PaginationRequest::new(after_cursor, order.into(), Some(limit), None, false);
+        let pagination = PaginationRequest::new(after_cursor, order, Some(limit), None, false);
         let db_response = self
             .get_live_cells_by_search_key(ctx.clone(), search_key, pagination)
             .await?;
@@ -304,12 +303,11 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         &self,
         ctx: Context,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: u64,
         after_cursor: Option<u64>,
     ) -> InnerResult<indexer::PaginationResponse<indexer::Transaction>> {
-        let pagination =
-            PaginationRequest::new(after_cursor, order.into(), Some(limit), None, false);
+        let pagination = PaginationRequest::new(after_cursor, order, Some(limit), None, false);
 
         let script = search_key.script;
         let (the_other_script, block_range) = if let Some(filter) = search_key.filter {
@@ -345,9 +343,9 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                 tx_index: cell.tx_index.into(),
                 io_index: cell.io_index.into(),
                 io_type: if cell.io_type == 0 {
-                    indexer::IOType::Input
+                    IOType::Input
                 } else {
-                    indexer::IOType::Output
+                    IOType::Output
                 },
             };
             objects.push(object);

--- a/core/rpc/core/src/impl/query.rs
+++ b/core/rpc/core/src/impl/query.rs
@@ -576,7 +576,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         Ok(GetTransactionInfoResponse {
             transaction: Some(transaction),
-            status: TransactionStatus::committed,
+            status: TransactionStatus::Committed,
         })
     }
 

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -210,7 +210,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         pagination.update_by_response(cell_page.next_cursor.map(Into::into));
 
         let mut cells = cell_page.response;
-        if extra == Some(ExtraType::CellBase) {
+        if extra == Some(ExtraType::Cellbase) {
             cells = cells
                 .into_iter()
                 .filter(|cell| cell.tx_index == 0)
@@ -271,7 +271,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         range: Option<Range>,
         pagination: PaginationRequest,
     ) -> InnerResult<PaginationResponse<TransactionWrapper>> {
-        let limit_cellbase = extra == Some(ExtraType::CellBase);
+        let limit_cellbase = extra == Some(ExtraType::Cellbase);
         let type_hashes = self.get_type_hashes(asset_infos, extra);
 
         let ret = match item {
@@ -679,7 +679,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         let tip_block_number = tip_block_number.unwrap_or(**CURRENT_BLOCK_NUMBER.load());
 
         if cell.tx_index == 0 && io_type == IOType::Output {
-            return Ok(Some(ExtraFilter::CellBase));
+            return Ok(Some(ExtraFilter::Cellbase));
         }
 
         if let Some(type_script) = cell.cell_output.type_().to_opt() {
@@ -758,11 +758,11 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             }
 
             // Except sUDT acp cell, sUDT secp and sUDT pw lock cell, cells with type setting can not spend its CKB.
-            return Ok(Some(ExtraFilter::Freeze));
+            return Ok(Some(ExtraFilter::Frozen));
         } else if !cell.cell_data.is_empty() {
             // If cell data is not empty but type is empty which often used for storing contract binary,
             // the ckb amount of this record should not be spent.
-            return Ok(Some(ExtraFilter::Freeze));
+            return Ok(Some(ExtraFilter::Frozen));
         }
 
         Ok(None)
@@ -863,7 +863,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                     }
                 },
 
-                Some(ExtraFilter::CellBase) => {
+                Some(ExtraFilter::Cellbase) => {
                     let epoch_number =
                         EpochNumberWithFraction::from_full_value(record.epoch_number.into())
                             .to_rational();
@@ -878,7 +878,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                     }
                 }
 
-                Some(ExtraFilter::Freeze) => amount - occupied,
+                Some(ExtraFilter::Frozen) => amount - occupied,
 
                 None => 0u128,
             };
@@ -1643,7 +1643,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                         .collect::<VecDeque<_>>();
                     ckb_cells_cache.cell_deque = dao_cells;
                 }
-                PoolCkbCategory::CkbCellBase => {
+                PoolCkbCategory::CkbCellbase => {
                     let mut asset_ckb_set = HashSet::new();
                     asset_ckb_set.insert(AssetInfo::new_ckb());
                     let ckb_cells = self
@@ -1673,7 +1673,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
                     ckb_cells_cache.cell_deque.append(&mut normal_ckb_cells);
                 }
                 PoolCkbCategory::CkbNormalSecp => {
-                    // database query optimization: when priority CellBase and NormalSecp are next to each other
+                    // database query optimization: when priority Cellbase and NormalSecp are next to each other
                     // database queries can be combined
                 }
                 PoolCkbCategory::CkbSecpUdt => {

--- a/core/rpc/core/src/impl/utils_types.rs
+++ b/core/rpc/core/src/impl/utils_types.rs
@@ -38,7 +38,7 @@ impl TransferComponents {
 #[derive(Debug, Copy, Clone)]
 pub enum PoolCkbCategory {
     DaoClaim,
-    CkbCellBase,
+    CkbCellbase,
     CkbAcp,
     CkbNormalSecp,
     CkbSecpUdt,
@@ -73,7 +73,7 @@ impl CkbCellsCache {
         for (item_index, _) in items.iter().enumerate() {
             for category_index in &[
                 PoolCkbCategory::DaoClaim,
-                PoolCkbCategory::CkbCellBase,
+                PoolCkbCategory::CkbCellbase,
                 PoolCkbCategory::CkbNormalSecp,
                 PoolCkbCategory::CkbSecpUdt,
                 PoolCkbCategory::CkbAcp,

--- a/core/rpc/core/src/lib.rs
+++ b/core/rpc/core/src/lib.rs
@@ -9,7 +9,7 @@ pub use r#impl::MercuryRpcImpl;
 
 use ckb_jsonrpc_types::Uint64;
 use ckb_types::{H160, H256};
-use common::Result;
+use common::{Order, Result};
 use core_rpc_types::error::MercuryRpcError;
 use core_rpc_types::{
     indexer, AdjustAccountPayload, BlockInfo, DaoClaimPayload, DaoDepositPayload,
@@ -110,7 +110,7 @@ pub trait MercuryRpc {
     async fn get_cells(
         &self,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: Uint64,
         after_cursor: Option<Uint64>,
     ) -> RpcResult<indexer::PaginationResponse<indexer::Cell>>;
@@ -125,7 +125,7 @@ pub trait MercuryRpc {
     async fn get_transactions(
         &self,
         search_key: indexer::SearchKey,
-        order: indexer::Order,
+        order: Order,
         limit: Uint64,
         after_cursor: Option<Uint64>,
     ) -> RpcResult<indexer::PaginationResponse<indexer::Transaction>>;

--- a/core/rpc/core/src/tests/mod.rs
+++ b/core/rpc/core/src/tests/mod.rs
@@ -26,9 +26,9 @@ use core_rpc_types::consts::{BYTE_SHANNONS, CHEQUE_CELL_CAPACITY, STANDARD_SUDT_
 use core_rpc_types::{
     AdjustAccountPayload, BlockInfo, DaoDepositPayload, DaoWithdrawPayload, GetBalancePayload,
     GetBalanceResponse, GetBlockInfoPayload, GetSpentTransactionPayload,
-    GetTransactionInfoResponse, MercuryInfo, QueryResponse, QueryTransactionsPayload,
-    SimpleTransferPayload, StructureType, SyncState, TransactionCompletionResponse,
-    TransactionStatus, TransferPayload, TxView,
+    GetTransactionInfoResponse, MercuryInfo, QueryTransactionsPayload, SimpleTransferPayload,
+    StructureType, SyncState, TransactionCompletionResponse, TransactionStatus, TransferPayload,
+    TxView,
 };
 use core_storage::{DBDriver, RelationalStorage, Storage};
 

--- a/core/rpc/types/src/indexer.rs
+++ b/core/rpc/types/src/indexer.rs
@@ -1,3 +1,5 @@
+use crate::IOType;
+
 use ckb_jsonrpc_types::{
     BlockNumber, Capacity, CellOutput, JsonBytes, OutPoint, Script, Uint32, Uint64,
 };
@@ -20,18 +22,11 @@ pub struct SearchKeyFilter {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
 pub enum ScriptType {
+    #[serde(alias = "lock")]
     Lock,
+    #[serde(alias = "type")]
     Type,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum Order {
-    #[serde(rename = "desc")]
-    Desc,
-    #[serde(rename = "asc")]
-    Asc,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -47,24 +42,6 @@ pub struct Cell {
 pub struct PaginationResponse<T> {
     pub objects: Vec<T>,
     pub last_cursor: Option<Uint64>,
-}
-
-impl From<common::Order> for Order {
-    fn from(order: common::Order) -> Order {
-        match order {
-            common::Order::Asc => Order::Asc,
-            common::Order::Desc => Order::Desc,
-        }
-    }
-}
-
-impl From<Order> for common::Order {
-    fn from(order: Order) -> common::Order {
-        match order {
-            Order::Asc => common::Order::Asc,
-            Order::Desc => common::Order::Desc,
-        }
-    }
 }
 
 impl From<common::DetailedCell> for Cell {
@@ -99,13 +76,6 @@ pub struct Transaction {
     pub tx_index: Uint32,
     pub io_index: Uint32,
     pub io_type: IOType,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum IOType {
-    Input,
-    Output,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -7,8 +7,7 @@ pub mod lazy;
 use crate::error::TypeError;
 
 use ckb_jsonrpc_types::{
-    BlockNumber, CellDep, CellOutput, OutPoint, Script, TransactionView, TransactionWithStatus,
-    Uint128, Uint32, Uint64,
+    BlockNumber, CellDep, CellOutput, OutPoint, Script, TransactionView, Uint128, Uint32, Uint64,
 };
 use ckb_types::{bytes::Bytes, H160, H256};
 use common::{derive_more::Display, utils::to_fixed_array, NetworkType, Order, Result};
@@ -21,7 +20,9 @@ pub const SECP256K1_WITNESS_LOCATION: (u32, u32) = (20, 65); // (offset, length)
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum AssetType {
+    #[serde(alias = "ckb")]
     CKB,
+    #[serde(alias = "udt")]
     UDT,
 }
 
@@ -61,26 +62,26 @@ pub enum ExtraFilter {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ExtraType {
+    #[serde(alias = "dao")]
     Dao,
+    #[serde(alias = "cellbase")]
     CellBase,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum StructureType {
+    #[serde(alias = "native")]
     Native,
+    #[serde(alias = "double_entry")]
     DoubleEntry,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum IOType {
+    #[serde(alias = "input")]
     Input,
+    #[serde(alias = "output")]
     Output,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum QueryType {
-    Cell,
-    Transaction,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -152,14 +153,19 @@ pub enum TransactionStatus {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum SinceFlag {
+    #[serde(alias = "relative")]
     Relative,
+    #[serde(alias = "absolute")]
     Absolute,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum SinceType {
+    #[serde(alias = "block_number")]
     BlockNumber,
+    #[serde(alias = "epoch_number")]
     EpochNumber,
+    #[serde(alias = "timestamp")]
     Timestamp,
 }
 
@@ -434,8 +440,8 @@ pub struct SudtIssuePayload {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ScriptGroupType {
-    LockScript,
-    TypeScript,
+    Lock,
+    Type,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -475,13 +481,17 @@ pub struct ToInfo {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq, Copy)]
 pub enum OutputCapacityProvider {
+    #[serde(alias = "from")]
     From,
+    #[serde(alias = "to")]
     To,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum PayFee {
+    #[serde(alias = "from")]
     From,
+    #[serde(alias = "to")]
     To,
 }
 
@@ -542,12 +552,6 @@ pub struct DaoClaimPayload {
 pub struct GetSpentTransactionPayload {
     pub outpoint: OutPoint,
     pub structure_type: StructureType,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum QueryResponse {
-    Cell(CellInfo),
-    Transaction(TransactionWithStatus),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)]
 pub mod consts;
 pub mod error;
 pub mod indexer;
@@ -54,10 +53,10 @@ impl AssetInfo {
 #[serde(tag = "type", content = "value")]
 pub enum ExtraFilter {
     Dao(DaoInfo),
-    CellBase,
+    Cellbase,
     /// Cell data or type is not empty, except Dao and Acp UDT cell.
     /// This is an important mark for accumulate_balance.
-    Freeze,
+    Frozen,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -65,7 +64,7 @@ pub enum ExtraType {
     #[serde(alias = "dao")]
     Dao,
     #[serde(alias = "cellbase")]
-    CellBase,
+    Cellbase,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
@@ -141,14 +140,13 @@ pub enum JsonItem {
     OutPoint(OutPoint),
 }
 
-#[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TransactionStatus {
-    pending,
-    proposed,
-    committed,
-    rejected,
-    unknown,
+    Pending,
+    Proposed,
+    Committed,
+    Rejected,
+    Unknown,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]

--- a/integration/src/utils/signer.rs
+++ b/integration/src/utils/signer.rs
@@ -27,7 +27,7 @@ pub fn sign_transaction(
     let tx: packed::Transaction = transaction.tx_view.inner.into();
     let mut witnesses: Vec<packed::Bytes> = tx.witnesses().into_iter().collect();
     for script_group in script_groups {
-        if script_group.group_type == ScriptGroupType::TypeScript {
+        if script_group.group_type == ScriptGroupType::Type {
             continue;
         }
         let pk = if let Some(pk) = get_right_pk(pks, &script_group.script) {

--- a/tests/tests/rpc/build_dao_deposit_transaction.rs
+++ b/tests/tests/rpc/build_dao_deposit_transaction.rs
@@ -46,7 +46,7 @@ fn test_dao_deposit_by_address() {
     assert_eq!(script_groups.len(), 3);
     let script_group = script_groups
         .iter()
-        .find(|s| s["group_type"] == "LockScript")
+        .find(|s| s["group_type"] == "Lock")
         .unwrap();
     assert_eq!(
         script_group["script"]["args"],

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -61,7 +61,7 @@ fn test_ckb_single_from_single_to() {
 
     let script_groups = &r["script_groups"].as_array().unwrap();
     assert_eq!(script_groups.len(), 1);
-    assert_eq!(script_groups[0]["group_type"], "LockScript");
+    assert_eq!(script_groups[0]["group_type"], "Lock");
     assert_eq!(
         script_groups[0]["script"]["args"],
         "0xfa22aa0aaf155a6c816634c61512046b08923111"
@@ -137,7 +137,7 @@ fn test_ckb_single_from_multiple_to() {
 
     let script_groups = &r["script_groups"].as_array().unwrap();
     assert_eq!(script_groups.len(), 1);
-    assert_eq!(script_groups[0]["group_type"], "LockScript");
+    assert_eq!(script_groups[0]["group_type"], "Lock");
     assert_eq!(
         script_groups[0]["script"]["args"],
         "0xfa22aa0aaf155a6c816634c61512046b08923111"
@@ -622,7 +622,7 @@ fn test_ckb_single_from_single_to_any_address() {
 
     let script_groups = &r["script_groups"].as_array().unwrap();
     assert_eq!(script_groups.len(), 1);
-    assert_eq!(script_groups[0]["group_type"], "LockScript");
+    assert_eq!(script_groups[0]["group_type"], "Lock");
     assert_eq!(
         script_groups[0]["script"]["args"],
         "0xfa22aa0aaf155a6c816634c61512046b08923111"

--- a/tests/tests/rpc/build_transfer_transaction.rs
+++ b/tests/tests/rpc/build_transfer_transaction.rs
@@ -32,8 +32,8 @@ fn test_ckb_single_from_single_to() {
                 "change": null,
                 "fee_rate": null,
                 "since": {
-                    "flag": "Absolute",
-                    "type_": "BlockNumber",
+                    "flag": "absolute",
+                    "type_": "block_number",
                     "value": "0x5b8d80"
                 }
             }
@@ -97,8 +97,8 @@ fn test_ckb_single_from_multiple_to() {
                         "amount": "0x4a817c800"
                     }
                 ],
-                "output_capacity_provider": "From",
-                "pay_fee": "From",
+                "output_capacity_provider": "from",
+                "pay_fee": "from",
                 "change": null,
                 "fee_rate": null,
                 "since": {
@@ -480,7 +480,7 @@ fn test_ckb_pay_fee() {
                     }
                 ],
                 "output_capacity_provider": "From",
-                "pay_fee": "To",
+                "pay_fee": "to",
                 "fee_rate": null,
                 "since": {
                     "flag": "Absolute",

--- a/tests/tests/rpc/common.rs
+++ b/tests/tests/rpc/common.rs
@@ -5,8 +5,8 @@ use std::{i64, slice::Iter};
 
 pub fn post_http_request(body: &'static str) -> serde_json::Value {
     let client = reqwest::blocking::Client::new();
-    let mercury_testnet_host = env::var("MERCURY_TESTNET_HOST")
-        .unwrap_or_else(|_| String::from("http://127.0.0.1:8116"));
+    let mercury_testnet_host =
+        env::var("MERCURY_TESTNET_HOST").unwrap_or_else(|_| String::from("http://127.0.0.1:8116"));
     let resp = client
         .post(mercury_testnet_host)
         .header("content-type", "application/json")

--- a/tests/tests/rpc/get_balance.rs
+++ b/tests/tests/rpc/get_balance.rs
@@ -48,7 +48,7 @@ fn test_address_udt() {
                 "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
             },
             "asset_infos": [{
-                "asset_type": "UDT",
+                "asset_type": "udt",
                 "udt_hash": "0xf21e7350fa9518ed3cbb008e0e8c941d7e01a12181931d5608aa366ee22228bd"
             }],
             "tip_block_number": "0x397d3a"

--- a/tests/tests/rpc/get_transaction_info.rs
+++ b/tests/tests/rpc/get_transaction_info.rs
@@ -16,7 +16,7 @@ fn test_existent_transaction() {
     );
     let r = &resp["result"];
 
-    assert_eq!(r["status"], "committed");
+    assert_eq!(r["status"], "Committed");
 
     let tx = &r["transaction"];
     assert_eq!(

--- a/tests/tests/rpc/query_transactions.rs
+++ b/tests/tests/rpc/query_transactions.rs
@@ -19,7 +19,7 @@ fn test_query_by_address() {
                 "extra": null,
                 "block_range": null,
                 "pagination": {
-                    "order": "desc",
+                    "order": "Desc",
                     "limit": "0x32",
                     "skip": null,
                     "return_count": true
@@ -153,7 +153,7 @@ fn test_query_by_address_asc() {
                 "extra": null,
                 "block_range": null,
                 "pagination": {
-                    "order": "asc",
+                    "order": "Asc",
                     "limit": "0x32",
                     "skip": null,
                     "return_count": true
@@ -199,7 +199,7 @@ fn test_query_by_address_ckb() {
                 },
                 "asset_infos": [
                     {
-                        "asset_type": "CKB",
+                        "asset_type": "ckb",
                         "udt_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
                     }
                 ],

--- a/tests/tests/rpc/query_transactions.rs
+++ b/tests/tests/rpc/query_transactions.rs
@@ -479,7 +479,7 @@ fn test_query_by_extra_dao() {
                     "value": "ckt1qyqrc4wkvc95f2wxguxaafwtgavpuqnqkxzqs0375w"
                 },
                 "asset_infos": [],
-                "extra": "Dao",
+                "extra": "dao",
                 "block_range": ["0x0", "0x7530"],
                 "pagination": {
                     "cursor": null,
@@ -513,7 +513,7 @@ fn test_query_by_extra_cellbase() {
                     "value": "ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vq06y24q4tc4tfkgze35cc23yprtpzfrzygsptkzn"
                 },
                 "asset_infos": [],
-                "extra": "CellBase",
+                "extra": "Cellbase",
                 "block_range": null,
                 "pagination": {
                     "cursor": null,
@@ -522,7 +522,7 @@ fn test_query_by_extra_cellbase() {
                     "skip": null,
                     "return_count": true
                 },
-                "structure_type": "DoubleEntry"
+                "structure_type": "double_entry"
             }
         ]
     }"#,
@@ -550,7 +550,7 @@ fn test_query_by_out_point_extra_cellbase() {
                     }
                 },
                 "asset_infos": [],
-                "extra": "CellBase",
+                "extra": "cellbase",
                 "block_range": null,
                 "pagination": {
                     "cursor": null,


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

* modify enum ScriptGroupType（LockScript/TypeScript -> Lock/Type）
* enum input parameters support snake name aliases
* break changes:
  * ExtraType::CellBase -> ExtraType::Cellbase (correct spelling)
  * ExtraFilter::CellBase -> ExtraFilter::Cellbase (correct spelling)
  * ExtraFilter::Freeze -> ExtraFilter::Frozen (uniform naming)
  * TransactionStatus::committed -> TransactionStatus::Committed（unified style：Capitalize the first letter of the output enume value）

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

Breaking Change

**Special notes for your reviewer**:

