### PR TITLE
refactor(rpc): update rpc type

### DIFF
--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -170,7 +170,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -248,7 +248,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -335,7 +335,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -467,7 +467,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -603,7 +603,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -690,7 +690,7 @@ echo '{
   ]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -876,7 +876,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1011,7 +1011,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1119,7 +1119,7 @@ echo '{
   ]]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1188,7 +1188,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1291,9 +1291,8 @@ echo '{
 
 ### Method `build_dao_withdraw_transaction`
 
-- `build_dao_withdraw_transaction(from, pay_fee, fee_rate)`
-  - `from`: [`JsonItem`](#type-jsonitem)
-  - `pay_fee`: `string|null`
+- `build_dao_withdraw_transaction(from, fee_rate)`
+  - `from`: `Array<`[`JsonItem`](#type-jsonitem)`>`
   - `fee_rate`: `Uint64|null`
 - result
   - `tx_view`: [`TransactionView`](https://github.com/nervosnetwork/ckb/blob/develop/rpc/README.md#type-transactionview)
@@ -1305,9 +1304,7 @@ To build a transaction to withdraw specified deposited CKB from DAO.
 
 **Params**
 
-- `from` - Specify the provider for the deposit cells.
-- `pay_fee` - Specify the account for paying the fee.
-  - If `pay_fee` is null, the `from` address pays the fee.
+- `from` - Specify the providers for the deposit cells and fee.
 - `fee_rate` -  The unit for the fee is shannon or KB. The default fee rate is 1000. 1 CKB = 10<sup>8</sup> shannons.
 
 **Returns**
@@ -1325,16 +1322,23 @@ echo '{
   "jsonrpc": "2.0",
   "method": "build_dao_withdraw_transaction",
   "params": [{
-    "from": {
-      "type": "Address",
-      "value": "ckt1qyqv3amsf8lf8g052fckahz2suqqgp4feetqt5xsgc"
-    },
-    "pay_fee": "ckt1qyqr79tnk3pp34xp92gerxjc4p3mus2690psf0dd70",
+    "from": [
+      {
+        "type": "OutPoint",
+        "value": {
+            "tx_hash": "0x1b9757e95346d4782767c579f1d1131ead18043154229762911f82b75119f1d6", 
+            "index": "0x0"
+          }
+      }, {
+        "type": "Address",
+        "value": "ckt1qyqr79tnk3pp34xp92gerxjc4p3mus2690psf0dd70"
+      }
+    ],
     "fee_rate": null
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-mainnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-mainnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1503,7 +1507,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1675,7 +1679,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1775,7 +1779,7 @@ echo '{
   "params": []
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1784,8 +1788,8 @@ echo '{
 {
   "jsonrpc": "2.0", 
   "result": {
-    "mercury_version": "0.3.1", 
-    "ckb_node_version": "v0.101", 
+    "mercury_version": "0.4.0", 
+    "ckb_node_version": "v0.103", 
     "network_type": "Testnet", 
     "enabled_extensions": [ ]
   }, 
@@ -1819,7 +1823,7 @@ echo '{
   "params": []
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -1828,7 +1832,7 @@ echo '{
 {
   "jsonrpc": "2.0", 
   "result": {
-    "version": "0.3.1", 
+    "version": "0.4.0", 
     "db": "PostgreSQL", 
     "conn_size": 100, 
     "center_id": 0, 
@@ -1897,7 +1901,7 @@ echo '{
   }]
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -2035,7 +2039,7 @@ echo '{
   "params": []
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -2102,7 +2106,7 @@ echo '{
   "params": []
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response
@@ -2137,7 +2141,7 @@ echo '{
   "params": []
 }' \
 | tr -d '\n' \
-| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.3
+| curl -H 'content-type: application/json' -d @- https://Mercury-testnet.ckbapp.dev/0.4
 ```
 
 - Response

--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -1479,7 +1479,7 @@ To build a transaction to claim specified withdrawing CKB from DAO.
 
 **Params**
 
-- `from` - Specify the providers for the withdrawing cells.
+- `from` - Specify the providers for the withdrawing cells and fee.
 - `to` - Specify the recipient of the claim.
   - If `to` is null, the CKB is claim to the first `from` address.
 - `fee_rate` -  The unit for the fee is shannon or KB. The default fee rate is 1000. 1 CKB = 10<sup>8</sup> shannons.
@@ -1844,11 +1844,11 @@ echo '{
 
 ### Method `build_sudt_issue_transaction`
 
-- `build_sudt_issue_transaction(owner, to, output_capacity_provider, pay_fee, fee_rate, since)`
+- `build_sudt_issue_transaction(owner, from, to, output_capacity_provider, fee_rate, since)`
   - `owner`: `string`
+  - `from`: `Array<`[`JsonItem`](#type-jsonitem)`>`
   - `to`: `Array<`[`ToInfo`](#type-toinfo)`>`
   - `output_capacity_provider`: `"From"|"To"|null`
-  - `pay_fee`: [`JsonItem`](#type-jsonitem)`|null`
   - `fee_rate`: `Uint64|null`
   - `since`: [`SinceConfig`](#type-sinceconfig)`|null`
 - result
@@ -1862,13 +1862,12 @@ To build a raw sUDT issuing transaction and script group for signing.
 **Params**
 
 - `owner` - Specify the owner address for the sUDT cell.
+- `from` - Specify the providers for capacity and fee, which must contain owner item.
 - `to` - Specify recipient's address, amount etc.
 - `output_capacity_provider` - Specify the party that provides capacity.
   - If it is `"From"`, it means that the `from` will provides the capacity required for the transfer, and the addresses of `to` represents the corresponding lock.
   - If it is `"To"`, it means that the `to` will provides the capacity required for the transfer, and the addresses of `to` must correspond to locks with acp behavior.
   - If it is `null`, same as `"To"`, it means that `from` will not provide the required capacity, and the addresses of `to` must correspond to locks with acp behavior.
-- `pay_fee` - Specify the account for paying the fee.
-  - If `pay_fee` is null, the `owner` address pays the fee.
 - `fee_rate` - The unit for the fee is shannon or KB. The default fee rate is 1000. 1 CKB = 10<sup>8</sup> shannons.
 - `since` - Specify the since configuration which prevents the transaction to be mined before a certain block timestamp or a block number.
 
@@ -1888,6 +1887,12 @@ echo '{
   "method": "build_sudt_issue_transaction",
   "params": [{
     "owner": "ckt1qyq9vxdzkgsdve78hexvgnvl66364ss05y3qqa6lgk",
+    "from": [
+      {
+        "type": "Address",
+        "value": "ckt1qyq9vxdzkgsdve78hexvgnvl66364ss05y3qqa6lgk"
+      }
+    ],
     "to": [
       {
         "address": "ckt1qyqz86vx4klk6lxv62lsdxr5qlmksewp6s7q2l6x9t",
@@ -1895,7 +1900,6 @@ echo '{
       }
     ],
     "output_capacity_provider": "From",
-    "pay_fee": null,
     "fee_rate": null,
     "since": null
   }]

--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -407,7 +407,7 @@ echo '{
   - `structure_type`: `"Native"|"DoubleEntry"`
 - result
   - `response`: `Array<`[`TxView`](#type-txview)`>`
-  - `next_cursor`: `string|null`
+  - `next_cursor`: `Uint64|null`
   - `count`: `Uint64|null`
 
 **Usage**
@@ -2287,7 +2287,7 @@ Fields
 Fields
 
 - `type` (Type: `"Deposit"|"Withdraw"`): Specify the type of dao state.
-- `value` (Type: `Uint64|Array<Uint64>`) : Specify the block number of a dao state.
+- `value` (Type: [`BlockNumber`](#type-blocknumber)`|Array`<[`BlockNumber`](#type-blocknumber)`>`) : Specify the block number of a dao state, when type is `"Deposit"`, value is a block number, in case type is `"Withdraw"`, value is size 2 array: `[block number, block number]`.
 
 ### Type `BurnInfo`
 

--- a/core/rpc/README.md
+++ b/core/rpc/README.md
@@ -1151,13 +1151,13 @@ To build a transaction to deposit specified amount of CKB to Dao.
 
 **Params**
 
-- `from` - Specify the provider of the CKB for Dao deposition.
+- `from` - Specify the providers of the CKB for Dao deposition.
   - The elements in the array must be the same kind of enumeration.
   - If `JsonItem` is an identity, the assets of addresses controlled by the identity will be pooled.
   - If `JsonItem` is an address, the assets of unspent records of the address will be pooled.
   - If `JsonItem` is an unspent out point, the assets of the out point will be pooled.
 - `to` - Specify the recipient of the deposit.
-  - If `to` is null, the CKB is deposited to the `from` address.
+  - If `to` is null, the CKB is deposited to the first `from` address.
 - `amount` - Specify the amount of CKB for the deposit. The deposit amount should larger than 200 CKB.
 - `fee_rate` - The unit for the fee is shannon or KB. The default fee rate is 1000. 1 CKB = 10<sup>8</sup> shannons.
 
@@ -1466,7 +1466,7 @@ echo '{
 ### Method `build_dao_claim_transaction`
 
 - `build_dao_claim_transaction(from, to, fee_rate)`
-  - `from`: [`JsonItem`](#type-jsonitem)
+  - `from`: `Array<`[`JsonItem`](#type-jsonitem)`>`
   - `to`: `string|null`
   - `fee_rate`: `Uint64|null`
 - result
@@ -1479,9 +1479,9 @@ To build a transaction to claim specified withdrawing CKB from DAO.
 
 **Params**
 
-- `from` - Specify the provider for the withdrawing cells.
+- `from` - Specify the providers for the withdrawing cells.
 - `to` - Specify the recipient of the claim.
-  - If `to` is null, the CKB is claim to the `from` address.
+  - If `to` is null, the CKB is claim to the first `from` address.
 - `fee_rate` -  The unit for the fee is shannon or KB. The default fee rate is 1000. 1 CKB = 10<sup>8</sup> shannons.
 
 **Returns**
@@ -1499,10 +1499,10 @@ echo '{
   "jsonrpc": "2.0",
   "method": "build_dao_claim_transaction",
   "params": [{
-    "from": {
+    "from": [{
       "type": "Address",
       "value": "ckt1qyqzqfj8lmx9h8vvhk62uut8us844v0yh2hsnqvvgc"
-    },
+    }],
     "fee_rate": null
   }]
 }' \

--- a/core/rpc/core/src/error.rs
+++ b/core/rpc/core/src/error.rs
@@ -139,6 +139,12 @@ pub enum CoreError {
 
     #[display(fmt = "Unsupport transfer mode: {}", _0)]
     UnsupportTransferMode(String),
+
+    #[display(fmt = "Amount should be positive")]
+    AmountMustPositive,
+
+    #[display(fmt = "When issuing udt from items must contain owner item")]
+    FromNotContainOwner,
 }
 
 impl RpcError for CoreError {
@@ -165,6 +171,7 @@ impl RpcError for CoreError {
             CoreError::ParseAddressError(_) => -11022,
             CoreError::ItemsNotSameEnumValue => -11023,
             CoreError::UnsupportIdentityFlag => -11024,
+            CoreError::AmountMustPositive => -11025,
 
             CoreError::UnsupportAddress => -11026,
             CoreError::InvalidTxPrebuilt(_) => -11027,
@@ -197,6 +204,7 @@ impl RpcError for CoreError {
             CoreError::InvalidOutPoint => -10111,
 
             CoreError::NeedAtLeastOneTo => -10120,
+            CoreError::FromNotContainOwner => -10121,
         }
     }
 

--- a/core/rpc/core/src/impl/adjust_account.rs
+++ b/core/rpc/core/src/impl/adjust_account.rs
@@ -139,7 +139,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
         // balance capacity
         let from = if from.is_empty() { vec![item] } else { from };
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             from,
             vec![],

--- a/core/rpc/core/src/impl/build_tx.rs
+++ b/core/rpc/core/src/impl/build_tx.rs
@@ -58,7 +58,6 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if MIN_DAO_CAPACITY > payload.amount.into() {
             return Err(CoreError::InvalidDAOCapacity.into());
         }
-        utils::check_same_enum_value(&payload.from)?;
         utils::dedup_json_items(&mut payload.from);
         self.build_transaction_with_adjusted_fee(
             Self::prebuild_dao_deposit_transaction,

--- a/core/rpc/core/src/impl/build_tx.rs
+++ b/core/rpc/core/src/impl/build_tx.rs
@@ -243,6 +243,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         for cell in deposit_cells {
             if self.is_script(&cell.cell_output.lock(), PW_LOCK)? {
                 transfer_components.script_deps.insert(PW_LOCK.to_string());
+                break;
             }
         }
 

--- a/core/rpc/core/src/impl/build_tx.rs
+++ b/core/rpc/core/src/impl/build_tx.rs
@@ -1,6 +1,7 @@
 use crate::r#impl::utils::{
     build_cell_for_output, build_cheque_args, calculate_cell_capacity,
-    calculate_unlock_epoch_number, dedup_json_items, is_dao_withdraw_unlock, to_since,
+    calculate_unlock_epoch_number, dedup_json_items, is_dao_withdraw_unlock, map_json_items,
+    to_since,
 };
 use crate::r#impl::{address_to_script, utils_types, utils_types::TransferComponents};
 use crate::{error::CoreError, InnerResult, MercuryRpcImpl};
@@ -1422,14 +1423,6 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         )
         .await
     }
-}
-
-fn map_json_items(json_items: Vec<JsonItem>) -> InnerResult<Vec<Item>> {
-    let items = json_items
-        .into_iter()
-        .map(Item::try_from)
-        .collect::<Result<Vec<Item>, _>>()?;
-    Ok(items)
 }
 
 pub(crate) fn calculate_tx_size(tx_view: &TransactionView) -> usize {

--- a/core/rpc/core/src/impl/build_tx.rs
+++ b/core/rpc/core/src/impl/build_tx.rs
@@ -103,7 +103,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         transfer_components.script_deps.insert(DAO.to_string());
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             items,
             vec![],
@@ -246,7 +246,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             vec![],
@@ -478,7 +478,6 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         if payload.from.len() > MAX_ITEM_NUM || payload.to.len() > MAX_ITEM_NUM {
             return Err(CoreError::ExceedMaxItemNum.into());
         }
-        utils::check_same_enum_value(&payload.from)?;
         utils::dedup_json_items(&mut payload.from);
         let addresses: Vec<String> = payload
             .to
@@ -573,7 +572,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             payload.to.into_iter().map(|info| info.address).collect(),
@@ -660,7 +659,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             payload.to.into_iter().map(|info| info.address).collect(),
@@ -725,7 +724,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         .await?;
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             payload.to.into_iter().map(|info| info.address).collect(),
@@ -813,7 +812,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         .await?;
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             payload.to.into_iter().map(|info| info.address).collect(),
@@ -1061,7 +1060,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
     }
 
     #[tracing_async]
-    pub(crate) async fn prebuild_capacity_balance_tx_by_from(
+    pub(crate) async fn prebuild_capacity_balance_tx(
         &self,
         ctx: Context,
         from_items: Vec<Item>,
@@ -1327,7 +1326,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             vec![],
@@ -1410,7 +1409,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         }
 
         // balance capacity
-        self.prebuild_capacity_balance_tx_by_from(
+        self.prebuild_capacity_balance_tx(
             ctx,
             map_json_items(payload.from)?,
             vec![],

--- a/core/rpc/core/src/impl/query.rs
+++ b/core/rpc/core/src/impl/query.rs
@@ -18,7 +18,7 @@ use ckb_types::{packed, prelude::*, H256};
 use num_bigint::{BigInt, Sign};
 use num_traits::{ToPrimitive, Zero};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::From;
 use std::ops::Neg;
 use std::{convert::TryInto, iter::Iterator};
@@ -67,7 +67,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             )
             .await?;
 
-        let mut balances_map: HashMap<(String, AssetInfo), Balance> = HashMap::new();
+        let mut balances_map: BTreeMap<(String, AssetInfo), Balance> = BTreeMap::new();
 
         for cell in live_cells {
             let records = self

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -2494,7 +2494,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
             }
         }
         for to_address in addresses {
-            if let Ok(identity) = self.address_to_identity(&to_address) {
+            if let Ok(identity) = self.address_to_identity(to_address) {
                 let to_item = Item::Identity(identity);
                 let to_ownership_lock_hash = self.get_default_owner_lock_by_item(&to_item).await?;
                 if from_ownership_lock_hash_set.contains(&to_ownership_lock_hash) {

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -31,7 +31,7 @@ use core_storage::{Storage, TransactionWrapper};
 use num_bigint::{BigInt, BigUint};
 use num_traits::{ToPrimitive, Zero};
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::str::FromStr;
 
@@ -824,7 +824,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
     pub(crate) async fn accumulate_balance_from_records(
         &self,
         ctx: Context,
-        balances_map: &mut HashMap<(String, AssetInfo), Balance>,
+        balances_map: &mut BTreeMap<(String, AssetInfo), Balance>,
         records: Vec<Record>,
         tip_epoch_number: Option<RationalU256>,
     ) -> InnerResult<()> {

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -1293,7 +1293,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         cells: &[packed::CellOutput],
         items: &[Item],
     ) -> Option<usize> {
-        for (index, output_cell) in cells.iter().enumerate() {
+        for (index, output_cell) in cells.iter().enumerate().rev() {
             if self
                 .is_acp_or_secp_belong_to_items(output_cell, items)
                 .await

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -2682,22 +2682,6 @@ pub fn build_cheque_args(receiver_address: Address, sender_address: Address) -> 
     ret.pack()
 }
 
-pub(crate) fn check_same_enum_value(items: &[JsonItem]) -> InnerResult<()> {
-    let all_items_is_same_variant = items.windows(2).all(|i| {
-        matches!(
-            (&i[0], &i[1]),
-            (JsonItem::Identity(_), JsonItem::Identity(_))
-                | (JsonItem::Address(_), JsonItem::Address(_))
-                | (JsonItem::OutPoint(_), JsonItem::OutPoint(_))
-        )
-    });
-    if all_items_is_same_variant {
-        Ok(())
-    } else {
-        Err(CoreError::ItemsNotSameEnumValue.into())
-    }
-}
-
 pub(crate) fn dedup_json_items(items: &mut Vec<JsonItem>) {
     let mut set = HashSet::new();
     items.retain(|i| set.insert(i.clone()));
@@ -2769,4 +2753,12 @@ pub(crate) fn calculate_cell_capacity(
         })
         .expect("calculate_cell_capacity")
         .as_u64()
+}
+
+pub(crate) fn map_json_items(json_items: Vec<JsonItem>) -> InnerResult<Vec<Item>> {
+    let items = json_items
+        .into_iter()
+        .map(Item::try_from)
+        .collect::<Result<Vec<Item>, _>>()?;
+    Ok(items)
 }

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -2480,29 +2480,29 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
         false
     }
 
-    pub(crate) async fn check_from_contain_to(
+    pub(crate) async fn is_items_contain_addresses(
         &self,
-        from_items: Vec<&JsonItem>,
-        to_addresses: Vec<String>,
-    ) -> InnerResult<()> {
+        items: &[JsonItem],
+        addresses: &[String],
+    ) -> InnerResult<bool> {
         let mut from_ownership_lock_hash_set = HashSet::new();
-        for json_item in from_items {
+        for json_item in items {
             let item = Item::try_from(json_item.to_owned())?;
             let lock_hash = self.get_default_owner_lock_by_item(&item).await;
             if let Ok(lock_hash) = lock_hash {
                 from_ownership_lock_hash_set.insert(lock_hash);
             }
         }
-        for to_address in to_addresses {
+        for to_address in addresses {
             if let Ok(identity) = self.address_to_identity(&to_address) {
                 let to_item = Item::Identity(identity);
                 let to_ownership_lock_hash = self.get_default_owner_lock_by_item(&to_item).await?;
                 if from_ownership_lock_hash_set.contains(&to_ownership_lock_hash) {
-                    return Err(CoreError::FromContainTo.into());
+                    return Ok(true);
                 }
             }
         }
-        Ok(())
+        Ok(false)
     }
 
     fn get_builtin_script(&self, builtin_script_name: &str, args: H160) -> packed::Script {

--- a/core/rpc/core/src/impl/utils.rs
+++ b/core/rpc/core/src/impl/utils.rs
@@ -985,7 +985,7 @@ impl<C: CkbRpc> MercuryRpcImpl<C> {
 
                 // receiver
                 if cell_args[0..20] == secp_lock_hash.0 {
-                    return !(record.asset_info.asset_type == AssetType::CKB);
+                    return record.asset_info.asset_type != AssetType::CKB;
                 }
 
                 // sender capacity

--- a/core/rpc/core/src/tests/utils_test.rs
+++ b/core/rpc/core/src/tests/utils_test.rs
@@ -124,41 +124,6 @@ fn test_to_since() {
 }
 
 #[test]
-fn test_check_same_enum_value() {
-    let items = vec![];
-    let ret = utils::check_same_enum_value(&items);
-    assert!(ret.is_ok());
-
-    let a = JsonItem::Identity("abc".to_string());
-    let items = vec![a];
-    let ret = utils::check_same_enum_value(&items);
-    assert!(ret.is_ok());
-
-    let a = JsonItem::Identity("bcd".to_string());
-    let b = JsonItem::Identity("abc".to_string());
-    let items = vec![a, b];
-    let ret = utils::check_same_enum_value(&items);
-    assert!(ret.is_ok());
-
-    let a = JsonItem::Identity("abc".to_string());
-    let b = JsonItem::Address("bcd".to_string());
-    let items = vec![a, b];
-    let ret = utils::check_same_enum_value(&items);
-    assert!(ret.is_err());
-
-    let a = JsonItem::Identity("abc".to_string());
-    let b = JsonItem::Address("bcd".to_string());
-    let c = JsonItem::OutPoint(OutPoint {
-        index: 0.into(),
-        tx_hash: H256::from_str("365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17")
-            .unwrap(),
-    });
-    let items = vec![a, b, c];
-    let ret = utils::check_same_enum_value(&items);
-    assert!(ret.is_err());
-}
-
-#[test]
 fn test_dedup_items() {
     let a1 = JsonItem::Identity("abc".to_string());
     let b1 = JsonItem::Identity("bcd".to_string());

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -13,11 +13,12 @@ use common::{derive_more::Display, utils::to_fixed_array, NetworkType, Order, Re
 use protocol::db::TransactionWrapper;
 use serde::{Deserialize, Serialize};
 
+use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use std::collections::HashSet;
 
 pub const SECP256K1_WITNESS_LOCATION: (u32, u32) = (20, 65); // (offset, length)
 
-#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AssetType {
     #[serde(alias = "ckb")]
     CKB,
@@ -25,7 +26,7 @@ pub enum AssetType {
     UDT,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Display, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Display, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[display(fmt = "Asset type {:?} hash {}", asset_type, udt_hash)]
 pub struct AssetInfo {
     pub asset_type: AssetType,

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -540,7 +540,7 @@ pub struct DaoWithdrawPayload {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DaoClaimPayload {
-    pub from: JsonItem,
+    pub from: Vec<JsonItem>,
     pub to: Option<String>,
     pub fee_rate: Option<Uint64>,
 }

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -534,8 +534,7 @@ pub struct DaoDepositPayload {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DaoWithdrawPayload {
-    pub from: JsonItem,
-    pub pay_fee: Option<String>,
+    pub from: Vec<JsonItem>,
     pub fee_rate: Option<Uint64>,
 }
 

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -429,9 +429,9 @@ impl TransactionCompletionResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct SudtIssuePayload {
     pub owner: String,
+    pub from: Vec<JsonItem>,
     pub to: Vec<ToInfo>,
     pub output_capacity_provider: Option<OutputCapacityProvider>,
-    pub pay_fee: Option<JsonItem>,
     pub fee_rate: Option<Uint64>,
     pub since: Option<SinceConfig>,
 }

--- a/core/rpc/types/src/lib.rs
+++ b/core/rpc/types/src/lib.rs
@@ -404,7 +404,7 @@ pub enum AccountType {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct AdjustAccountPayload {
     pub item: JsonItem,
-    pub from: HashSet<JsonItem>,
+    pub from: Vec<JsonItem>,
     pub asset_info: AssetInfo,
     pub account_number: Option<Uint32>,
     pub extra_ckb: Option<Uint64>,

--- a/integration/src/tests/build_adjust_account_transaction.rs
+++ b/integration/src/tests/build_adjust_account_transaction.rs
@@ -170,10 +170,10 @@ fn test_adjust_account_from_multi() {
         .build_adjust_account_transaction(adjust_account_payload)
         .unwrap()
         .unwrap();
-    let tx = sign_transaction(tx, &[address_pk.to_owned()]).unwrap();
+    let tx = sign_transaction(tx, &[address_pk]).unwrap();
     let _tx_hash = send_transaction_to_ckb(tx).unwrap();
 
-    let response = mercury_client.get_balance(payload.clone()).unwrap();
+    let response = mercury_client.get_balance(payload).unwrap();
     assert_eq!(response.balances.len(), 1);
     assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
 

--- a/integration/src/tests/build_adjust_account_transaction.rs
+++ b/integration/src/tests/build_adjust_account_transaction.rs
@@ -83,7 +83,6 @@ fn test_adjust_account_pw_lock() {
     };
     let response = mercury_client.get_balance(payload.clone()).unwrap();
     assert_eq!(response.balances.len(), 1);
-    println!("{:?}", response.balances[0]);
     assert_eq!(5_0000_0000u128, response.balances[0].free.into());
     assert_eq!(710_0000_0000u128, response.balances[0].occupied.into());
 
@@ -92,7 +91,6 @@ fn test_adjust_account_pw_lock() {
 
     let response = mercury_client.get_balance(payload.clone()).unwrap();
     assert_eq!(response.balances.len(), 1);
-    println!("{:?}", response.balances[0]);
     assert!(572_0000_0000u128 < response.balances[0].free.into());
     assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
 
@@ -101,7 +99,6 @@ fn test_adjust_account_pw_lock() {
 
     let response = mercury_client.get_balance(payload).unwrap();
     assert_eq!(response.balances.len(), 1);
-    println!("{:?}", response.balances[0]);
     assert!(714_0000_0000u128 < response.balances[0].free.into());
     assert_eq!(0u128, response.balances[0].occupied.into());
 }

--- a/integration/src/tests/build_adjust_account_transaction.rs
+++ b/integration/src/tests/build_adjust_account_transaction.rs
@@ -2,11 +2,12 @@ use super::IntegrationTest;
 use crate::const_definition::{MERCURY_URI, UDT_1_HASH};
 use crate::utils::address::{build_acp_address, build_pw_lock_address};
 use crate::utils::instruction::{
-    issue_udt_1, prepare_account, prepare_secp_address_with_ckb_capacity,
+    issue_udt_1, prepare_account, prepare_secp_address_with_ckb_capacity, send_transaction_to_ckb,
 };
 use crate::utils::rpc_client::MercuryRpcClient;
+use crate::utils::signer::sign_transaction;
 
-use core_rpc_types::{AssetInfo, GetBalancePayload, JsonItem};
+use core_rpc_types::{AdjustAccountPayload, AssetInfo, GetBalancePayload, JsonItem};
 
 use std::collections::HashSet;
 
@@ -88,4 +89,97 @@ fn test_adjust_account_pw_lock() {
     // account number: 0
     let ret = prepare_account(udt_hash, &pw_lock_address, &address, &address_pk, Some(0));
     assert!(ret.is_err());
+}
+
+inventory::submit!(IntegrationTest {
+    name: "test_adjust_account_from_multi",
+    test_fn: test_adjust_account_from_multi
+});
+fn test_adjust_account_from_multi() {
+    // issue udt
+    issue_udt_1().unwrap();
+    let udt_hash = UDT_1_HASH.get().unwrap();
+
+    let (address, address_pk, out_point) =
+        prepare_secp_address_with_ckb_capacity(1000_0000_0000).unwrap();
+    let acp_address = build_acp_address(&address).unwrap();
+
+    // acp number: 5
+    let adjust_account_payload = AdjustAccountPayload {
+        item: JsonItem::Address(acp_address.to_string()),
+        from: vec![
+            JsonItem::OutPoint(out_point.clone()),
+            JsonItem::Address(address.to_string()),
+        ],
+        asset_info: AssetInfo::new_udt(udt_hash.to_owned()),
+        account_number: Some(5u32.into()),
+        extra_ckb: None,
+        fee_rate: None,
+    };
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let tx = mercury_client
+        .build_adjust_account_transaction(adjust_account_payload)
+        .unwrap()
+        .unwrap();
+    let tx = sign_transaction(tx, &[address_pk.to_owned()]).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(acp_address.to_string()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let response = mercury_client.get_balance(payload.clone()).unwrap();
+    assert_eq!(response.balances.len(), 1);
+    assert_eq!(710_0000_0000u128, response.balances[0].occupied.into());
+
+    // account number: 1
+    let adjust_account_payload = AdjustAccountPayload {
+        item: JsonItem::Address(acp_address.to_string()),
+        from: vec![
+            JsonItem::OutPoint(out_point.clone()),
+            JsonItem::Address(address.to_string()),
+        ],
+        asset_info: AssetInfo::new_udt(udt_hash.to_owned()),
+        account_number: Some(1u32.into()),
+        extra_ckb: None,
+        fee_rate: None,
+    };
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let tx = mercury_client
+        .build_adjust_account_transaction(adjust_account_payload)
+        .unwrap()
+        .unwrap();
+    let tx = sign_transaction(tx, &[address_pk.to_owned()]).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    let response = mercury_client.get_balance(payload.clone()).unwrap();
+    assert_eq!(response.balances.len(), 1);
+    assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
+
+    // account number: 0
+    let adjust_account_payload = AdjustAccountPayload {
+        item: JsonItem::Address(acp_address.to_string()),
+        from: vec![
+            JsonItem::OutPoint(out_point),
+            JsonItem::Address(address.to_string()),
+        ],
+        asset_info: AssetInfo::new_udt(udt_hash.to_owned()),
+        account_number: Some(0u32.into()),
+        extra_ckb: None,
+        fee_rate: None,
+    };
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let tx = mercury_client
+        .build_adjust_account_transaction(adjust_account_payload)
+        .unwrap()
+        .unwrap();
+    let tx = sign_transaction(tx, &[address_pk.to_owned()]).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    let response = mercury_client.get_balance(payload).unwrap();
+    assert_eq!(response.balances.len(), 0);
 }

--- a/integration/src/tests/build_adjust_account_transaction.rs
+++ b/integration/src/tests/build_adjust_account_transaction.rs
@@ -1,13 +1,19 @@
 use super::IntegrationTest;
-use crate::const_definition::{MERCURY_URI, UDT_1_HASH};
-use crate::utils::address::{build_acp_address, build_pw_lock_address};
+use crate::const_definition::{
+    MERCURY_URI, UDT_1_HASH, UDT_1_HOLDER_ACP_ADDRESS, UDT_1_HOLDER_ACP_ADDRESS_PK,
+};
+use crate::utils::address::{
+    build_acp_address, build_pw_lock_address, new_identity_from_secp_address,
+};
 use crate::utils::instruction::{
     issue_udt_1, prepare_account, prepare_secp_address_with_ckb_capacity, send_transaction_to_ckb,
 };
 use crate::utils::rpc_client::MercuryRpcClient;
 use crate::utils::signer::sign_transaction;
 
-use core_rpc_types::{AdjustAccountPayload, AssetInfo, GetBalancePayload, JsonItem};
+use core_rpc_types::{
+    AdjustAccountPayload, AssetInfo, GetBalancePayload, JsonItem, ToInfo, TransferPayload,
+};
 
 use std::collections::HashSet;
 
@@ -77,18 +83,27 @@ fn test_adjust_account_pw_lock() {
     };
     let response = mercury_client.get_balance(payload.clone()).unwrap();
     assert_eq!(response.balances.len(), 1);
+    println!("{:?}", response.balances[0]);
+    assert_eq!(5_0000_0000u128, response.balances[0].free.into());
     assert_eq!(710_0000_0000u128, response.balances[0].occupied.into());
 
     // account number: 1
     prepare_account(udt_hash, &pw_lock_address, &address, &address_pk, Some(1)).unwrap();
 
-    let response = mercury_client.get_balance(payload).unwrap();
+    let response = mercury_client.get_balance(payload.clone()).unwrap();
     assert_eq!(response.balances.len(), 1);
+    println!("{:?}", response.balances[0]);
+    assert!(572_0000_0000u128 < response.balances[0].free.into());
     assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
 
     // account number: 0
-    let ret = prepare_account(udt_hash, &pw_lock_address, &address, &address_pk, Some(0));
-    assert!(ret.is_err());
+    prepare_account(udt_hash, &pw_lock_address, &address, &address_pk, Some(0)).unwrap();
+
+    let response = mercury_client.get_balance(payload).unwrap();
+    assert_eq!(response.balances.len(), 1);
+    println!("{:?}", response.balances[0]);
+    assert!(714_0000_0000u128 < response.balances[0].free.into());
+    assert_eq!(0u128, response.balances[0].occupied.into());
 }
 
 inventory::submit!(IntegrationTest {
@@ -99,6 +114,8 @@ fn test_adjust_account_from_multi() {
     // issue udt
     issue_udt_1().unwrap();
     let udt_hash = UDT_1_HASH.get().unwrap();
+    let udt_holder_address = UDT_1_HOLDER_ACP_ADDRESS.get().unwrap();
+    let udt_holder_address_pk = UDT_1_HOLDER_ACP_ADDRESS_PK.get().unwrap();
 
     let (address, address_pk, out_point) =
         prepare_secp_address_with_ckb_capacity(1000_0000_0000).unwrap();
@@ -160,6 +177,26 @@ fn test_adjust_account_from_multi() {
     assert_eq!(response.balances.len(), 1);
     assert_eq!(142_0000_0000u128, response.balances[0].occupied.into());
 
+    // transfer udt
+    let from_identity = new_identity_from_secp_address(&udt_holder_address.to_string()).unwrap();
+    let transfer_payload = TransferPayload {
+        asset_info: AssetInfo::new_udt(udt_hash.to_owned()),
+        from: vec![JsonItem::Identity(hex::encode(from_identity.0))],
+        to: vec![ToInfo {
+            address: acp_address.to_string(),
+            amount: 80u128.into(),
+        }],
+        output_capacity_provider: None,
+        pay_fee: None,
+        fee_rate: None,
+        since: None,
+    };
+    let tx = mercury_client
+        .build_transfer_transaction(transfer_payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &[udt_holder_address_pk.to_owned()]).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
     // account number: 0
     let adjust_account_payload = AdjustAccountPayload {
         item: JsonItem::Address(acp_address.to_string()),
@@ -173,13 +210,7 @@ fn test_adjust_account_from_multi() {
         fee_rate: None,
     };
     let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
-    let tx = mercury_client
-        .build_adjust_account_transaction(adjust_account_payload)
-        .unwrap()
-        .unwrap();
-    let tx = sign_transaction(tx, &[address_pk.to_owned()]).unwrap();
-    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+    let tx = mercury_client.build_adjust_account_transaction(adjust_account_payload);
 
-    let response = mercury_client.get_balance(payload).unwrap();
-    assert_eq!(response.balances.len(), 0);
+    assert!(tx.is_err());
 }

--- a/integration/src/tests/build_dao_related_transaction.rs
+++ b/integration/src/tests/build_dao_related_transaction.rs
@@ -187,7 +187,7 @@ inventory::submit!(IntegrationTest {
     test_fn: test_dao_by_out_point
 });
 fn test_dao_by_out_point() {
-    let (address_1, address_pk_1, _) =
+    let (address_1, address_pk_1, out_point_1) =
         prepare_secp_address_with_ckb_capacity(300_0000_0000).expect("prepare ckb");
     let (address_2, address_pk_2, _) =
         prepare_secp_address_with_ckb_capacity(300_0000_0000).expect("prepare ckb");
@@ -197,7 +197,10 @@ fn test_dao_by_out_point() {
 
     // deposit 1
     let payload = DaoDepositPayload {
-        from: vec![JsonItem::Address(address_1.to_string())],
+        from: vec![
+            JsonItem::OutPoint(out_point_1),
+            JsonItem::Address(address_1.to_string()),
+        ],
         to: None,
         amount: 200_0000_0000.into(),
         fee_rate: None,

--- a/integration/src/tests/build_dao_related_transaction.rs
+++ b/integration/src/tests/build_dao_related_transaction.rs
@@ -61,7 +61,7 @@ fn test_dao_by_address() {
 
     // claim
     let claim_payload = DaoClaimPayload {
-        from: JsonItem::Address(address.to_string()),
+        from: vec![JsonItem::Address(address.to_string())],
         to: None,
         fee_rate: None,
     };
@@ -126,7 +126,7 @@ fn test_dao_pool_money() {
 
     // claim
     let claim_payload = DaoClaimPayload {
-        from: JsonItem::Address(address.to_string()),
+        from: vec![JsonItem::Address(address.to_string())],
         to: None,
         fee_rate: None,
     };
@@ -270,20 +270,18 @@ fn test_dao_by_out_point() {
     assert!(tx.is_err());
 
     // claim
-    let claim_payload_1 = DaoClaimPayload {
-        from: JsonItem::Address(address_1.to_string()),
+    let claim_payload = DaoClaimPayload {
+        from: vec![
+            JsonItem::Address(address_1.to_string()),
+            JsonItem::Address(address_2.to_string()),
+        ],
         to: None,
         fee_rate: None,
     };
-    let claim_payload_2 = DaoClaimPayload {
-        from: JsonItem::Address(address_2.to_string()),
-        to: None,
-        fee_rate: None,
-    };
-    let tx = mercury_client.build_dao_claim_transaction(claim_payload_1.clone());
+    let tx = mercury_client.build_dao_claim_transaction(claim_payload.clone());
     assert!(tx.is_err());
 
-    fast_forward_epochs(4).unwrap();
+    fast_forward_epochs(5).unwrap();
 
     // withdraw
     let tx = mercury_client
@@ -294,16 +292,9 @@ fn test_dao_by_out_point() {
 
     fast_forward_epochs(180).unwrap();
 
-    // claim 1
+    // claim
     let tx = mercury_client
-        .build_dao_claim_transaction(claim_payload_1)
-        .unwrap();
-    let tx = sign_transaction(tx, &pks).unwrap();
-    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
-
-    // claim 2
-    let tx = mercury_client
-        .build_dao_claim_transaction(claim_payload_2)
+        .build_dao_claim_transaction(claim_payload)
         .unwrap();
     let tx = sign_transaction(tx, &pks).unwrap();
     let _tx_hash = send_transaction_to_ckb(tx).unwrap();
@@ -312,13 +303,13 @@ fn test_dao_by_out_point() {
     let balance_1 = mercury_client.get_balance(balance_payload_1).unwrap();
     assert_eq!(balance_1.balances.len(), 1);
     assert_eq!(balance_1.balances[0].asset_info.asset_type, AssetType::CKB);
-    assert!(balance_1.balances[0].free > 300_0000_0000u128.into());
+    assert!(balance_1.balances[0].free > 500_0000_0000u128.into());
 
     // get_balance 2
     let balance_2 = mercury_client.get_balance(balance_payload_2).unwrap();
     assert_eq!(balance_2.balances.len(), 1);
     assert_eq!(balance_2.balances[0].asset_info.asset_type, AssetType::CKB);
-    assert!(balance_2.balances[0].free > 300_0000_0000u128.into());
+    assert!(balance_2.balances[0].free < 100_0000_0000u128.into());
 
     assert!(balance_1.balances[0].free > balance_2.balances[0].free);
 }

--- a/integration/src/tests/build_dao_related_transaction.rs
+++ b/integration/src/tests/build_dao_related_transaction.rs
@@ -7,6 +7,7 @@ use crate::utils::instruction::{
 use crate::utils::rpc_client::MercuryRpcClient;
 use crate::utils::signer::sign_transaction;
 
+use ckb_jsonrpc_types::OutPoint;
 use core_rpc_types::{
     AssetInfo, AssetType, DaoClaimPayload, DaoDepositPayload, DaoWithdrawPayload,
     GetBalancePayload, JsonItem, OutputCapacityProvider, ToInfo, TransferPayload,
@@ -15,10 +16,10 @@ use core_rpc_types::{
 use std::collections::HashSet;
 
 inventory::submit!(IntegrationTest {
-    name: "test_dao",
-    test_fn: test_dao
+    name: "test_dao_by_address",
+    test_fn: test_dao_by_address
 });
-fn test_dao() {
+fn test_dao_by_address() {
     let (address, address_pk, _) =
         prepare_secp_address_with_ckb_capacity(300_0000_0000).expect("prepare ckb");
     let pks = vec![address_pk];
@@ -52,8 +53,7 @@ fn test_dao() {
 
     // withdraw
     let withdraw_payload = DaoWithdrawPayload {
-        from: JsonItem::Address(address.to_string()),
-        pay_fee: None,
+        from: vec![JsonItem::Address(address.to_string())],
         fee_rate: None,
     };
     let tx = mercury_client.build_dao_withdraw_transaction(withdraw_payload.clone());
@@ -118,8 +118,7 @@ fn test_dao_pool_money() {
 
     // withdraw
     let withdraw_payload = DaoWithdrawPayload {
-        from: JsonItem::Address(address.to_string()),
-        pay_fee: None,
+        from: vec![JsonItem::Address(address.to_string())],
         fee_rate: None,
     };
     let tx = mercury_client.build_dao_withdraw_transaction(withdraw_payload.clone());
@@ -181,4 +180,145 @@ fn test_dao_pool_money() {
     assert_eq!(balance.balances.len(), 1);
     assert_eq!(balance.balances[0].asset_info.asset_type, AssetType::CKB);
     assert!(balance.balances[0].free > 100_0000_0000u128.into());
+}
+
+inventory::submit!(IntegrationTest {
+    name: "test_dao_by_out_point",
+    test_fn: test_dao_by_out_point
+});
+fn test_dao_by_out_point() {
+    let (address_1, address_pk_1, _) =
+        prepare_secp_address_with_ckb_capacity(300_0000_0000).expect("prepare ckb");
+    let (address_2, address_pk_2, _) =
+        prepare_secp_address_with_ckb_capacity(300_0000_0000).expect("prepare ckb");
+    let pks = vec![address_pk_1, address_pk_2];
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+
+    // deposit 1
+    let payload = DaoDepositPayload {
+        from: vec![JsonItem::Address(address_1.to_string())],
+        to: None,
+        amount: 200_0000_0000.into(),
+        fee_rate: None,
+    };
+    let tx = mercury_client
+        .build_dao_deposit_transaction(payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let tx_hash = send_transaction_to_ckb(tx).unwrap();
+    let out_point_deposit_1 = OutPoint {
+        tx_hash,
+        index: 0.into(),
+    };
+
+    // deposit 2
+    let payload = DaoDepositPayload {
+        from: vec![JsonItem::Address(address_2.to_string())],
+        to: None,
+        amount: 200_0000_0000.into(),
+        fee_rate: None,
+    };
+    let tx = mercury_client
+        .build_dao_deposit_transaction(payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let tx_hash = send_transaction_to_ckb(tx).unwrap();
+    let out_point_deposit_2 = OutPoint {
+        tx_hash,
+        index: 0.into(),
+    };
+
+    // get balance of address 1
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let balance_payload_1 = GetBalancePayload {
+        item: JsonItem::Address(address_1.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client
+        .get_balance(balance_payload_1.clone())
+        .unwrap();
+    assert_eq!(balance.balances.len(), 1);
+    assert_eq!(balance.balances[0].asset_info.asset_type, AssetType::CKB);
+    assert_eq!(balance.balances[0].occupied, 102_0000_0000u128.into());
+
+    // get balance of address 2
+    let balance_payload_2 = GetBalancePayload {
+        item: JsonItem::Address(address_2.to_string()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let balance = mercury_client
+        .get_balance(balance_payload_2.clone())
+        .unwrap();
+    assert_eq!(balance.balances.len(), 1);
+    assert_eq!(balance.balances[0].asset_info.asset_type, AssetType::CKB);
+    assert_eq!(balance.balances[0].occupied, 102_0000_0000u128.into());
+
+    // withdraw
+    let withdraw_payload = DaoWithdrawPayload {
+        from: vec![
+            JsonItem::OutPoint(out_point_deposit_1),
+            JsonItem::OutPoint(out_point_deposit_2),
+            JsonItem::Address(address_2.to_string()),
+        ],
+        fee_rate: None,
+    };
+    let tx = mercury_client.build_dao_withdraw_transaction(withdraw_payload.clone());
+    assert!(tx.is_err());
+
+    // claim
+    let claim_payload_1 = DaoClaimPayload {
+        from: JsonItem::Address(address_1.to_string()),
+        to: None,
+        fee_rate: None,
+    };
+    let claim_payload_2 = DaoClaimPayload {
+        from: JsonItem::Address(address_2.to_string()),
+        to: None,
+        fee_rate: None,
+    };
+    let tx = mercury_client.build_dao_claim_transaction(claim_payload_1.clone());
+    assert!(tx.is_err());
+
+    fast_forward_epochs(4).unwrap();
+
+    // withdraw
+    let tx = mercury_client
+        .build_dao_withdraw_transaction(withdraw_payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    fast_forward_epochs(180).unwrap();
+
+    // claim 1
+    let tx = mercury_client
+        .build_dao_claim_transaction(claim_payload_1)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    // claim 2
+    let tx = mercury_client
+        .build_dao_claim_transaction(claim_payload_2)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx).unwrap();
+
+    // get_balance 1
+    let balance_1 = mercury_client.get_balance(balance_payload_1).unwrap();
+    assert_eq!(balance_1.balances.len(), 1);
+    assert_eq!(balance_1.balances[0].asset_info.asset_type, AssetType::CKB);
+    assert!(balance_1.balances[0].free > 300_0000_0000u128.into());
+
+    // get_balance 2
+    let balance_2 = mercury_client.get_balance(balance_payload_2).unwrap();
+    assert_eq!(balance_2.balances.len(), 1);
+    assert_eq!(balance_2.balances[0].asset_info.asset_type, AssetType::CKB);
+    assert!(balance_2.balances[0].free > 300_0000_0000u128.into());
+
+    assert!(balance_1.balances[0].free > balance_2.balances[0].free);
 }

--- a/integration/src/tests/build_simple_transfer_transaction.rs
+++ b/integration/src/tests/build_simple_transfer_transaction.rs
@@ -216,12 +216,7 @@ fn test_simple_transfer_udt_from_provide_capacity() {
         tip_block_number: None,
     };
     let from_balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, _udt_balance) =
-        if from_balance.balances[0].asset_info.asset_type == AssetType::CKB {
-            (&from_balance.balances[0], &from_balance.balances[1])
-        } else {
-            (&from_balance.balances[1], &from_balance.balances[0])
-        };
+    let (ckb_balance, _udt_balance) = (&from_balance.balances[0], &from_balance.balances[1]);
     assert_eq!(from_balance.balances.len(), 2);
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());
 }

--- a/integration/src/tests/build_sudt_issue_transaction.rs
+++ b/integration/src/tests/build_sudt_issue_transaction.rs
@@ -1,12 +1,19 @@
 use super::IntegrationTest;
 use crate::const_definition::MERCURY_URI;
 use crate::utils::address::{
-    generate_rand_secp_address_pk_pair, get_udt_hash_by_owner, new_identity_from_secp_address,
+    build_acp_address, generate_rand_secp_address_pk_pair, get_udt_hash_by_owner,
+    new_identity_from_secp_address,
 };
-use crate::utils::instruction::{issue_udt_with_cheque, prepare_secp_address_with_ckb_capacity};
+use crate::utils::instruction::{
+    issue_udt_with_cheque, prepare_account, prepare_secp_address_with_ckb_capacity,
+    send_transaction_to_ckb,
+};
 use crate::utils::rpc_client::MercuryRpcClient;
+use crate::utils::signer::sign_transaction;
 
-use core_rpc_types::{AssetInfo, GetBalancePayload, JsonItem};
+use core_rpc_types::{
+    AssetInfo, GetBalancePayload, JsonItem, OutputCapacityProvider, SudtIssuePayload, ToInfo,
+};
 
 use std::collections::HashSet;
 
@@ -40,4 +47,99 @@ fn test_issue_udt_from_provide_capacity() {
 
     assert_eq!(to_balance.balances.len(), 1);
     assert_eq!(udt_balance.free, 100u128.into());
+}
+
+inventory::submit!(IntegrationTest {
+    name: "test_issue_udt_from_multi_item",
+    test_fn: test_issue_udt_from_multi_item
+});
+fn test_issue_udt_from_multi_item() {
+    // prepare
+    let (owner_address, owner_pk, _) =
+        prepare_secp_address_with_ckb_capacity(250_0000_0000).expect("prepare ckb");
+    let (from_address, from_address_pk, _) =
+        prepare_secp_address_with_ckb_capacity(250_0000_0000).expect("prepare ckb");
+    let pks = vec![owner_pk, from_address_pk];
+    let (to_address, to_address_pk, _) =
+        prepare_secp_address_with_ckb_capacity(150_0000_0000).expect("prepare ckb");
+
+    // issue udt
+    let payload = SudtIssuePayload {
+        owner: owner_address.to_string(),
+        from: vec![
+            JsonItem::Address(owner_address.to_string()),
+            JsonItem::Address(from_address.to_string()),
+        ],
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 100.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        fee_rate: None,
+        since: None,
+    };
+
+    // build tx
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let tx = mercury_client
+        .build_sudt_issue_transaction(payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+
+    // send tx to ckb node
+    send_transaction_to_ckb(tx).unwrap();
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+
+    // get balance of to identity, AssetType::UDT
+    let to_identity = new_identity_from_secp_address(&to_address.to_string()).unwrap();
+    let udt_hash = get_udt_hash_by_owner(&owner_address).unwrap();
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_udt(udt_hash.clone()));
+    let payload_to = GetBalancePayload {
+        item: JsonItem::Identity(to_identity.encode()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let to_balance = mercury_client.get_balance(payload_to.clone()).unwrap();
+    let udt_balance = &to_balance.balances[0];
+
+    assert_eq!(to_balance.balances.len(), 1);
+    assert_eq!(udt_balance.free, 100u128.into());
+
+    // additional issue udt
+    prepare_account(&udt_hash, &to_address, &to_address, &to_address_pk, Some(1)).unwrap();
+    let to_acp_address = build_acp_address(&to_address).unwrap();
+
+    let payload = SudtIssuePayload {
+        owner: owner_address.to_string(),
+        from: vec![
+            JsonItem::Address(owner_address.to_string()),
+            JsonItem::Address(from_address.to_string()),
+        ],
+        to: vec![ToInfo {
+            address: to_acp_address.to_string(),
+            amount: 100.into(),
+        }],
+        output_capacity_provider: None,
+        fee_rate: None,
+        since: None,
+    };
+
+    // build tx
+    let tx = mercury_client
+        .build_sudt_issue_transaction(payload)
+        .unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+
+    // send tx to ckb node
+    send_transaction_to_ckb(tx).unwrap();
+
+    // get balance of to identity, AssetType::UDT
+    let to_balance = mercury_client.get_balance(payload_to).unwrap();
+    let udt_balance = &to_balance.balances;
+
+    assert_eq!(to_balance.balances.len(), 2);
+    assert_eq!(udt_balance[0].free, 100u128.into());
+    assert_eq!(udt_balance[1].free, 100u128.into());
 }

--- a/integration/src/tests/build_transfer_transaction_ckb.rs
+++ b/integration/src/tests/build_transfer_transaction_ckb.rs
@@ -206,10 +206,10 @@ inventory::submit!(IntegrationTest {
     test_fn: test_transfer_ckb_from_provide_capacity_out_point
 });
 fn test_transfer_ckb_from_provide_capacity_out_point() {
-    let (_from_1_address, from_1_pk, out_point_1) =
+    let (from_1_address, from_1_pk, out_point_1) =
         prepare_secp_address_with_ckb_capacity(200_0000_0000).expect("prepare ckb");
 
-    let (from_2_address, from_2_pk, out_point_2) =
+    let (from_2_address, from_2_pk, _out_point_2) =
         prepare_secp_address_with_ckb_capacity(200_0000_0000).expect("prepare ckb");
     let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
 
@@ -236,7 +236,8 @@ fn test_transfer_ckb_from_provide_capacity_out_point() {
         asset_info: AssetInfo::new_ckb(),
         from: vec![
             JsonItem::OutPoint(out_point_1),
-            JsonItem::OutPoint(out_point_2),
+            JsonItem::Address(from_1_address.to_string()),
+            JsonItem::Address(from_2_address.to_string()),
         ],
         to: vec![ToInfo {
             address: to_address.to_string(),

--- a/integration/src/tests/build_transfer_transaction_ckb.rs
+++ b/integration/src/tests/build_transfer_transaction_ckb.rs
@@ -1,6 +1,8 @@
 use super::IntegrationTest;
 use crate::const_definition::{MERCURY_URI, UDT_1_HASH};
-use crate::utils::address::{build_acp_address, generate_rand_secp_address_pk_pair};
+use crate::utils::address::{
+    build_acp_address, generate_rand_secp_address_pk_pair, new_identity_from_secp_address,
+};
 use crate::utils::instruction::{
     issue_udt_1, prepare_account, prepare_secp_address_with_ckb_capacity, send_transaction_to_ckb,
 };
@@ -144,12 +146,16 @@ fn test_transfer_ckb_to_provide_capacity() {
 }
 
 inventory::submit!(IntegrationTest {
-    name: "test_change",
-    test_fn: test_change
+    name: "test_change_to_new_output",
+    test_fn: test_change_to_new_output
 });
-fn test_change() {
+fn test_change_to_new_output() {
     // prepare ckb
-    let (from_address, from_pk, _) =
+    let (from_address_1, from_pk_1, _out_point_1) =
+        prepare_secp_address_with_ckb_capacity(250_0000_0000).expect("prepare ckb");
+    let (from_address_2, from_pk_2, out_point_2) =
+        prepare_secp_address_with_ckb_capacity(400_0000_0000).expect("prepare ckb");
+    let (from_address_3, from_pk_3, _out_point_3) =
         prepare_secp_address_with_ckb_capacity(650_0000_0000).expect("prepare ckb");
     let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
 
@@ -157,31 +163,45 @@ fn test_change() {
     issue_udt_1().unwrap();
     prepare_account(
         UDT_1_HASH.get().unwrap(),
-        &from_address,
-        &from_address,
-        &from_pk,
+        &from_address_1,
+        &from_address_1,
+        &from_pk_1,
         Some(1),
     )
     .unwrap();
+    let from_acp_address_1 = build_acp_address(&from_address_1).unwrap();
 
-    // get balance
+    let pks = vec![from_pk_1, from_pk_2, from_pk_3];
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+
+    // get balance 1
     let mut asset_infos = HashSet::new();
     asset_infos.insert(AssetInfo::new_ckb());
     let payload = GetBalancePayload {
-        item: JsonItem::Address(from_address.to_string()),
+        item: JsonItem::Address(from_address_1.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    assert!(107u128 < balance.balances[0].free.into());
+
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_acp_address_1.to_string()),
         asset_infos,
         tip_block_number: None,
     };
-    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
     let balance = mercury_client.get_balance(payload).unwrap();
-    let ckb_balance = &balance.balances[0];
-    assert_eq!(balance.balances.len(), 1);
-    assert!(500u128 < ckb_balance.free.into());
+    assert!(142u128 < balance.balances[0].occupied.into());
 
     // transfer
     let payload = TransferPayload {
         asset_info: AssetInfo::new_ckb(),
-        from: vec![JsonItem::Address(from_address.to_string())],
+        from: vec![
+            JsonItem::Address(from_address_1.to_string()), // 107+ free ckb
+            JsonItem::OutPoint(out_point_2),               // 400 free ckb
+            JsonItem::Address(from_address_3.to_string()), // 650 free ckb
+        ],
         to: vec![ToInfo {
             address: to_address.to_string(),
             amount: 400_0000_0000u128.into(),
@@ -193,12 +213,25 @@ fn test_change() {
     };
     let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
     let tx = mercury_client.build_transfer_transaction(payload).unwrap();
-    let tx = sign_transaction(tx, &[from_pk]).unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
     let _tx_hash = send_transaction_to_ckb(tx.clone());
 
     // change is enough to build an output, so there is no need to put change into acp
-    assert_eq!(1, tx.inputs.len());
+    assert_eq!(2, tx.inputs.len());
     assert_eq!(2, tx.outputs.len());
+
+    // get balance 2
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_address_2.to_string()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    let ckb_balance = &balance.balances[0];
+    assert_eq!(balance.balances.len(), 1);
+    assert!(107u128 < ckb_balance.free.into()); // new change cell
 }
 
 inventory::submit!(IntegrationTest {
@@ -461,4 +494,190 @@ fn test_transfer_ckb_to_provide_capacity_to_pay_fee() {
     assert_eq!(balance.balances.len(), 1);
     assert!(242_0000_0000u128 > to_free_capacity + to_occupied_capacity);
     assert!(241_0000_0000u128 < to_free_capacity + to_occupied_capacity);
+}
+
+inventory::submit!(IntegrationTest {
+    name: "test_change_to_acp",
+    test_fn: test_change_to_acp
+});
+fn test_change_to_acp() {
+    // prepare ckb
+    let (from_address_1, from_pk_1, _out_point_1) =
+        prepare_secp_address_with_ckb_capacity(250_0000_0000).expect("prepare ckb");
+    let (from_address_2, from_pk_2, _out_point_2) =
+        prepare_secp_address_with_ckb_capacity(400_0000_0000).expect("prepare ckb");
+    let (from_address_3, from_pk_3, _out_point_3) =
+        prepare_secp_address_with_ckb_capacity(650_0000_0000).expect("prepare ckb");
+    let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
+
+    // prepare acp 1
+    issue_udt_1().unwrap();
+    prepare_account(
+        UDT_1_HASH.get().unwrap(),
+        &from_address_1,
+        &from_address_1,
+        &from_pk_1,
+        Some(1),
+    )
+    .unwrap();
+    let from_acp_address_1 = build_acp_address(&from_address_1).unwrap();
+
+    // prepare acp 2
+    prepare_account(
+        UDT_1_HASH.get().unwrap(),
+        &from_address_2,
+        &from_address_2,
+        &from_pk_2,
+        Some(1),
+    )
+    .unwrap();
+    let from_acp_address_2 = build_acp_address(&from_address_2).unwrap();
+
+    let pks = vec![from_pk_1, from_pk_2, from_pk_3];
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+
+    // get balance 1
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_address_1.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    assert!(107_0000_0000u128 < balance.balances[0].free.into());
+
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_acp_address_1.to_string()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    assert_eq!(142_0000_0000u128, balance.balances[0].occupied.into());
+
+    // transfer
+    let identity_1 = new_identity_from_secp_address(&from_address_1.to_string()).unwrap();
+    let identity_2 = new_identity_from_secp_address(&from_address_2.to_string()).unwrap();
+    let payload = TransferPayload {
+        asset_info: AssetInfo::new_ckb(),
+        from: vec![
+            JsonItem::Identity(hex::encode(identity_1.0)), // 107+ free ckb + acp cell
+            JsonItem::Identity(hex::encode(identity_2.0)), // 257+ free ckb + acp cell
+            JsonItem::Address(from_address_3.to_string()), // 650 free ckb
+        ],
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 350_0000_0000u128.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
+        fee_rate: None,
+        since: None,
+    };
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+    let tx = mercury_client.build_transfer_transaction(payload).unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx.clone());
+
+    // change is not enough to build an output, so change into acp(output/db)
+    assert_eq!(3, tx.inputs.len());
+    assert_eq!(2, tx.outputs.len());
+
+    // get balance 3
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_address_3.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    let ckb_balance = &balance.balances[0];
+    assert_eq!(balance.balances.len(), 1);
+    assert_eq!(650_0000_0000u128, ckb_balance.free.into());
+
+    // get balance 2 acp
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_acp_address_2.to_string()),
+        asset_infos,
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    let ckb_balance = &balance.balances[0];
+    assert_eq!(balance.balances.len(), 1);
+    assert_eq!(142_0000_0000u128, ckb_balance.occupied.into());
+
+    // get balance 1 acp
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_acp_address_1.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    let ckb_balance = &balance.balances[0];
+    assert_eq!(balance.balances.len(), 1);
+    assert_eq!(142_0000_0000u128, ckb_balance.occupied.into());
+    assert!(15_0000_0000u128 < ckb_balance.free.into());
+}
+
+inventory::submit!(IntegrationTest {
+    name: "test_change_need_pool",
+    test_fn: test_change_need_pool
+});
+fn test_change_need_pool() {
+    // prepare ckb
+    let (from_address_1, from_pk_1, _out_point_1) =
+        prepare_secp_address_with_ckb_capacity(100_0000_0000).expect("prepare ckb");
+    let (from_address_2, from_pk_2, _out_point_2) =
+        prepare_secp_address_with_ckb_capacity(100_0000_0000).expect("prepare ckb");
+    let (from_address_3, from_pk_3, _out_point_3) =
+        prepare_secp_address_with_ckb_capacity(100_0000_0000).expect("prepare ckb");
+    let (to_address, _to_pk) = generate_rand_secp_address_pk_pair();
+
+    let pks = vec![from_pk_1, from_pk_2, from_pk_3];
+
+    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
+
+    // transfer
+    let payload = TransferPayload {
+        asset_info: AssetInfo::new_ckb(),
+        from: vec![
+            JsonItem::Address(from_address_1.to_string()), // 100 free ckb
+            JsonItem::Address(from_address_2.to_string()), // 100 free ckb
+            JsonItem::Address(from_address_3.to_string()), // 100 free ckb
+        ],
+        to: vec![ToInfo {
+            address: to_address.to_string(),
+            amount: 195_0000_0000u128.into(),
+        }],
+        output_capacity_provider: Some(OutputCapacityProvider::From),
+        pay_fee: None,
+        fee_rate: None,
+        since: None,
+    };
+    let tx = mercury_client.build_transfer_transaction(payload).unwrap();
+    let tx = sign_transaction(tx, &pks).unwrap();
+    let _tx_hash = send_transaction_to_ckb(tx.clone());
+
+    // change is not enough to build an output
+    // no acp
+    // so need pool a cell from db, build change cell
+    assert_eq!(3, tx.inputs.len());
+    assert_eq!(2, tx.outputs.len());
+
+    // get balance 2
+    let mut asset_infos = HashSet::new();
+    asset_infos.insert(AssetInfo::new_ckb());
+    let payload = GetBalancePayload {
+        item: JsonItem::Address(from_address_2.to_string()),
+        asset_infos: asset_infos.clone(),
+        tip_block_number: None,
+    };
+    let balance = mercury_client.get_balance(payload).unwrap();
+    let ckb_balance = &balance.balances[0];
+    assert_eq!(balance.balances.len(), 1);
+    assert!(104_0000_0000u128 < ckb_balance.free.into());
 }

--- a/integration/src/tests/build_transfer_transaction_udt.rs
+++ b/integration/src/tests/build_transfer_transaction_udt.rs
@@ -294,12 +294,7 @@ fn test_transfer_udt_to_provide_capacity_from_receiver_cheque_change_udt() {
         tip_block_number: None,
     };
     let from_balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) =
-        if from_balance.balances[0].asset_info.asset_type == AssetType::CKB {
-            (&from_balance.balances[0], &from_balance.balances[1])
-        } else {
-            (&from_balance.balances[1], &from_balance.balances[0])
-        };
+    let (ckb_balance, udt_balance) = (&from_balance.balances[0], &from_balance.balances[1]);
     assert_eq!(from_balance.balances.len(), 2);
     assert_ne!(ckb_balance.free, 0u128.into());
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());

--- a/integration/src/tests/build_transfer_transaction_udt.rs
+++ b/integration/src/tests/build_transfer_transaction_udt.rs
@@ -378,12 +378,7 @@ fn test_transfer_udt_to_provide_capacity_from_receiver_has_cheque_change_udt_to_
         tip_block_number: None,
     };
     let from_balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) =
-        if from_balance.balances[0].asset_info.asset_type == AssetType::CKB {
-            (&from_balance.balances[0], &from_balance.balances[1])
-        } else {
-            (&from_balance.balances[1], &from_balance.balances[0])
-        };
+    let (ckb_balance, udt_balance) = (&from_balance.balances[0], &from_balance.balances[1]);
     assert_eq!(from_balance.balances.len(), 2);
     assert_ne!(ckb_balance.free, 0u128.into());
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());
@@ -482,12 +477,8 @@ fn test_transfer_udt_to_provide_capacity_from_out_point_cheque_part_claim() {
         tip_block_number: None,
     };
     let balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
+
     assert_eq!(balance.balances.len(), 2);
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());
     assert_eq!(udt_balance.free, 20u128.into());
@@ -566,12 +557,8 @@ fn test_transfer_udt_to_provide_capacity_from_cheque_address_part_claim() {
         tip_block_number: None,
     };
     let balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
+
     assert_eq!(balance.balances.len(), 2);
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());
     assert_eq!(udt_balance.free, 20u128.into());
@@ -620,12 +607,8 @@ fn test_transfer_udt_from_provide_capacity_acp() {
         tip_block_number: None,
     };
     let to_balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) =
-        if to_balance.balances[0].asset_info.asset_type == AssetType::CKB {
-            (&to_balance.balances[0], &to_balance.balances[1])
-        } else {
-            (&to_balance.balances[1], &to_balance.balances[0])
-        };
+    let (ckb_balance, udt_balance) = (&to_balance.balances[0], &to_balance.balances[1]);
+
     assert_eq!(to_balance.balances.len(), 2);
     assert_eq!(ckb_balance.free, 0u128.into());
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());
@@ -693,13 +676,8 @@ fn test_transfer_udt_to_provide_capacity_from_sender_has_cheque_part_withdraw() 
         tip_block_number: None,
     };
     let balance = mercury_client.get_balance(payload).unwrap();
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
 
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
     assert_eq!(balance.balances.len(), 2);
     assert!(107_0000_0000u128 < ckb_balance.free.into());
     assert_eq!(ckb_balance.occupied, 142_0000_0000u128.into());

--- a/integration/src/tests/get_balance.rs
+++ b/integration/src/tests/get_balance.rs
@@ -52,12 +52,8 @@ fn test_get_balance_of_udt_1_holder_address() {
     };
     let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
     let balance = mercury_client.get_balance(payload).unwrap();
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
+
     assert_eq!(balance.balances.len(), 2);
     println!("UDT_1_HOLDER_ACP_ADDRESS:");
     println!("  ckb free: {:?}", ckb_balance.free);
@@ -173,12 +169,8 @@ fn test_get_balance_of_item_has_cheque() {
         tip_block_number: None,
     };
     let balance = mercury_client.get_balance(payload_out_point).unwrap();
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
+
     assert_eq!(ckb_balance.occupied, 162_0000_0000u128.into());
     assert_eq!(ckb_balance.free, 0u128.into());
     assert_eq!(udt_balance.free, 100u128.into());
@@ -190,12 +182,8 @@ fn test_get_balance_of_item_has_cheque() {
         tip_block_number: None,
     };
     let balance = mercury_client.get_balance(payload_out_point).unwrap();
-    let (ckb_balance, udt_balance) = if balance.balances[0].asset_info.asset_type == AssetType::CKB
-    {
-        (&balance.balances[0], &balance.balances[1])
-    } else {
-        (&balance.balances[1], &balance.balances[0])
-    };
+    let (ckb_balance, udt_balance) = (&balance.balances[0], &balance.balances[1]);
+
     assert_eq!(balance.balances.len(), 2);
     assert_eq!(ckb_balance.occupied, 162_0000_0000u128.into());
     assert_eq!(ckb_balance.free, 0u128.into());

--- a/integration/src/utils/instruction.rs
+++ b/integration/src/utils/instruction.rs
@@ -278,12 +278,12 @@ pub(crate) fn issue_udt_with_cheque(
         build_cheque_address(to_address, owner_address).expect("build cheque address");
     let payload = SudtIssuePayload {
         owner: owner_address.to_string(),
+        from: vec![JsonItem::Address(owner_address.to_string())],
         to: vec![ToInfo {
             address: cheque_address.to_string(),
             amount: udt_amount.into(),
         }],
         output_capacity_provider: Some(OutputCapacityProvider::From),
-        pay_fee: None,
         fee_rate: None,
         since: None,
     };

--- a/integration/src/utils/instruction.rs
+++ b/integration/src/utils/instruction.rs
@@ -25,7 +25,6 @@ use core_rpc_types::{
     SimpleTransferPayload, SudtIssuePayload, ToInfo, TransferPayload,
 };
 
-use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::panic;
 use std::process::{Child, Command};
@@ -304,13 +303,10 @@ pub(crate) fn prepare_account(
     from_address_pk: &H256,
     account_number: Option<u32>,
 ) -> Result<()> {
-    let mut from = HashSet::new();
-    from.insert(JsonItem::Address(from_address.to_string()));
-    let asset_info = AssetInfo::new_udt(udt_hash.to_owned());
     let payload = AdjustAccountPayload {
         item: JsonItem::Address(item.to_string()),
-        from,
-        asset_info,
+        from: vec![JsonItem::Address(from_address.to_string())],
+        asset_info: AssetInfo::new_udt(udt_hash.to_owned()),
         account_number: account_number.map(Into::into),
         extra_ckb: None,
         fee_rate: None,

--- a/tests/tests/rpc/build_dao_withdraw_transaction.rs
+++ b/tests/tests/rpc/build_dao_withdraw_transaction.rs
@@ -10,10 +10,10 @@ fn test_dao_withdraw_by_address() {
         "method": "build_dao_withdraw_transaction",
         "params": [
             {
-                "from": {
+                "from": [{
                     "type": "Address",
                     "value": "ckt1qyqrc4wkvc95f2wxguxaafwtgavpuqnqkxzqs0375w"
-                },
+                }],
                 "fee_rate": "0x3e8"
             }
         ]

--- a/tests/tests/rpc/build_sudt_issue_transaction.rs
+++ b/tests/tests/rpc/build_sudt_issue_transaction.rs
@@ -12,6 +12,12 @@ fn test_address() {
         "params": [
             {
                 "owner": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9",
+                "from": [
+                    {
+                        "type": "Address",
+                        "value": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq06y24q4tc4tfkgze35cc23yprtpzfrzygljdjh9"
+                    }
+                ],
                 "to": [
                     {
                         "address": "ckt1qqdpunl0xn6es2gx7azmqj870vggjer7sg6xqa8q7vkzan3xea43uqt6g2dxvxxjtdhfvfs0f67gwzgrcrfg3gj9yywse6zu05ez3s64xmtdkl6074rac6q3f7cvk",
@@ -19,7 +25,6 @@ fn test_address() {
                     }
                 ],
                 "output_capacity_provider": "From",
-                "pay_fee": null,
                 "fee_rate": "0x3e8",
                 "since": null
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Breaking Change：

- rpc Type `SudtIssuePayload` add `from` array filed, remove `pay_fee` filed
- rpc Type `DaoWithdrawPayload`  support `from` array input, remove `pay_fee` filed
- rpc Type `DaoClaimPayload` support `from` array input
- rpc `from` filed with Type `Vec<JsonItem>`, remove limit by `check_same_enum_value`
- rpc Type `AdjustAccountPayload` filed `from` modify Type from `HashSet<JsonItem>` to `Vec<JsonItem>` for unity

Maintenance:

- fix and udpate rpc readme doc
- removed the limitation that the number of accounts based on pw lock cannot be fully recycled
- the results of `get_balance` can be output in a certain order

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

Breaking Change

**Special notes for your reviewer**:

