### PR TITLE
fix(rpc):  transactions generated by rpc `build_dao_claim_transaction` will cause random `-14` dao script validation error

### DIFF
--- a/core/storage/src/relational/fetch.rs
+++ b/core/storage/src/relational/fetch.rs
@@ -243,8 +243,7 @@ impl RelationalStorage {
                 let input_tables = txs_input_cells
                     .get(&tx.tx_hash.inner)
                     .cloned()
-                    .or(Some(vec![]))
-                    .expect("impossible: get cell table fail");
+                    .unwrap_or_default();
                 let mut inputs = build_cell_inputs(input_tables.iter());
                 if inputs.is_empty() && tx.tx_index == 0 {
                     inputs = vec![build_cell_base_input(tx.block_number)]
@@ -253,8 +252,7 @@ impl RelationalStorage {
                 let output_tables = txs_output_cells
                     .get(&tx.tx_hash.inner)
                     .cloned()
-                    .or(Some(vec![]))
-                    .expect("impossible: get cell table fail");
+                    .unwrap_or_default();
                 let (outputs, outputs_data) = build_cell_outputs(&output_tables);
 
                 let transaction_view = build_transaction_view(

--- a/integration/README.md
+++ b/integration/README.md
@@ -2,7 +2,7 @@
 
 ### Preconditions
 
-- install Ckb (compile and install with the latest `develop` branch)
+- [install Ckb](https://docs.nervos.org/docs/basics/guides/get-ckb/#build-from-source) (compile and install with the latest release version)
 - install and start PostgreSQL
 - create new database `mercury-dev`, if it already exists, delete it first and then re-create it
 - create tables and indexes

--- a/integration/README.md
+++ b/integration/README.md
@@ -18,7 +18,6 @@ Note: only needs to be executed once at initialization and reinitialization.
 ```bash
 cd integration
 rm -rf ./dev_chain/dev/data  ./free-space
-ckb import -C dev data/ckb_dev.json
 ```
 
 ### Run integration tests

--- a/integration/src/tests/build_dao_related_transaction.rs
+++ b/integration/src/tests/build_dao_related_transaction.rs
@@ -284,7 +284,7 @@ fn test_dao_by_out_point() {
     let tx = mercury_client.build_dao_claim_transaction(claim_payload.clone());
     assert!(tx.is_err());
 
-    fast_forward_epochs(5).unwrap();
+    fast_forward_epochs(4).unwrap();
 
     // withdraw
     let tx = mercury_client
@@ -293,7 +293,7 @@ fn test_dao_by_out_point() {
     let tx = sign_transaction(tx, &pks).unwrap();
     let _tx_hash = send_transaction_to_ckb(tx).unwrap();
 
-    fast_forward_epochs(180).unwrap();
+    fast_forward_epochs(176).unwrap();
 
     // claim
     let tx = mercury_client

--- a/integration/src/utils/instruction.rs
+++ b/integration/src/utils/instruction.rs
@@ -22,7 +22,7 @@ use common::lazy::{
 use common::Address;
 use core_rpc_types::{
     AdjustAccountPayload, AssetInfo, AssetType, IOType, JsonItem, OutputCapacityProvider,
-    SimpleTransferPayload, SudtIssuePayload, ToInfo, TransferPayload,
+    SudtIssuePayload, ToInfo, TransferPayload,
 };
 use serde::Serialize;
 
@@ -148,54 +148,17 @@ pub(crate) fn issue_udt_1() -> Result<()> {
 
     // issue udt
     let (owner_address, owner_address_pk, _) =
-        prepare_secp_address_with_ckb_capacity(250_0000_0000)?;
-    let udt_hash = get_udt_hash_by_owner(&owner_address)?;
-    let (receiver_secp_address, receiver_address_pk, _) =
-        prepare_secp_address_with_ckb_capacity(100_0000_0000)?;
-    let _tx_hash = issue_udt_with_cheque(
-        &owner_address,
-        &owner_address_pk,
-        &receiver_secp_address,
-        20_000_000_000u128,
-    );
-
-    // new acp account for to
-    let (holder_address, holder_address_pk, _) =
         prepare_secp_address_with_ckb_capacity(500_0000_0000)?;
-    prepare_account(
-        &udt_hash,
-        &holder_address,
-        &holder_address,
-        &holder_address_pk,
-        Some(1),
-    )?;
-
-    // build tx transfer udt to acp address
-    let payload = SimpleTransferPayload {
-        asset_info: AssetInfo::new_udt(udt_hash.clone()),
-        from: vec![receiver_secp_address.to_string()],
-        to: vec![ToInfo {
-            address: holder_address.to_string(),
-            amount: 20_000_000_000u128.into(),
-        }],
-        fee_rate: None,
-        since: None,
-    };
-    let mercury_client = MercuryRpcClient::new(MERCURY_URI.to_string());
-    let tx = mercury_client.build_simple_transfer_transaction(payload)?;
-    let tx = sign_transaction(tx, &[receiver_address_pk])?;
-
-    // send tx to ckb node
-    let _tx_hash = send_transaction_to_ckb(tx)?;
-
-    let acp_address = build_acp_address(&holder_address)?;
+    let udt_hash = get_udt_hash_by_owner(&owner_address)?;
+    let _tx_hash = issue_udt_with_acp(&owner_address, &owner_address_pk, 20_000_000_000u128)?;
+    let acp_address = build_acp_address(&owner_address)?;
 
     UDT_1_HASH.set(udt_hash).expect("init UDT_HASH_1");
     UDT_1_HOLDER_ACP_ADDRESS
         .set(acp_address)
         .expect("init UDT_1_HOLDER_ACP_ADDRESS");
     UDT_1_HOLDER_ACP_ADDRESS_PK
-        .set(holder_address_pk)
+        .set(owner_address_pk)
         .expect("init UDT_1_HOLDER_ACP_ADDRESS_PK");
     Ok(())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

- Fixed a randomly failing integration test: `test_dao_by_out_point`
  - description: Sometimes a failure occurs when running `test_dao_by_out_point`, in this test case, the withdrawing cells are from different transactions.
  - reason: `get_transactions_with_status` returns the `input_cells` in the transaction but the order is not guaranteed to be in the order in the transaction. In this case, `build_dao_claim_transaction` relies on the assumption that the `input_cells` are in order to locate the deposit cells by withdrawing cells’ outpoint index.

- refactored integration test `test_simple_transfer_udt_from_provide_capacity`：avoid the possibility of affecting other tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

